### PR TITLE
Removing sim references

### DIFF
--- a/.github/workflows/cmake-ubuntu.yml
+++ b/.github/workflows/cmake-ubuntu.yml
@@ -2,7 +2,7 @@ name: Compile on Ubuntu & Test
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "removingSimRefsTest" ]
     paths-ignore:
       - '**/README.md'
   pull_request:

--- a/.github/workflows/cmake-ubuntu.yml
+++ b/.github/workflows/cmake-ubuntu.yml
@@ -2,7 +2,7 @@ name: Compile on Ubuntu & Test
 
 on:
   push:
-    branches: [ "master", "removingSimRefsTest" ]
+    branches: [ "master" ]
     paths-ignore:
       - '**/README.md'
   pull_request:

--- a/include/bosonic_exchange/bosonic_exchange_base.h
+++ b/include/bosonic_exchange/bosonic_exchange_base.h
@@ -1,8 +1,7 @@
 #pragma once
 
 #include "common.h"
-
-class Simulation; // Forward declaration
+#include "params.h"
 
 /**
  * @class BosonicExchangeBase
@@ -15,7 +14,7 @@ class Simulation; // Forward declaration
  */
 class BosonicExchangeBase {
 public:
-    BosonicExchangeBase(const Simulation& _sim);
+    BosonicExchangeBase(Params& param_obj, const dVec& coord, const dVec& prev_coord, const dVec& next_coord, int this_bead);
     virtual ~BosonicExchangeBase() = default;
     BosonicExchangeBase(const BosonicExchangeBase&) = delete;
     BosonicExchangeBase& operator=(const BosonicExchangeBase&) = delete;
@@ -40,13 +39,15 @@ protected:
     virtual void springForceFirstBead(dVec& f) = 0;
     virtual void springForceLastBead(dVec& f) = 0;
 
-    const Simulation& sim; // Reference to the simulation object
-
-    const int nbosons;
-    const int nbeads;
+    int nbosons;
+    int nbeads;
+    int this_bead;
 
     double spring_constant;
     double beta;
+    double size;
+
+    bool pbc;
 
     const dVec& x;
     const dVec& x_prev;

--- a/include/bosonic_exchange/factorial_bosonic_exchange.h
+++ b/include/bosonic_exchange/factorial_bosonic_exchange.h
@@ -5,7 +5,7 @@
 
 class FactorialBosonicExchange final : public BosonicExchangeBase {
 public:
-    FactorialBosonicExchange(const Simulation& _sim);
+    FactorialBosonicExchange(Params& param_obj, const dVec& coord, const dVec& prev_coord, const dVec& next_coord, const int this_bead);
     ~FactorialBosonicExchange() override = default;
 
     double effectivePotential() override;

--- a/include/bosonic_exchange/quadratic_bosonic_exchange.h
+++ b/include/bosonic_exchange/quadratic_bosonic_exchange.h
@@ -5,7 +5,7 @@
 
 class BosonicExchange final : public BosonicExchangeBase {
 public:
-    BosonicExchange(const Simulation& _sim);
+    BosonicExchange(Params& param_obj, const dVec& coord, const dVec& prev_coord, const dVec& next_coord, const int this_bead);
     ~BosonicExchange() override = default;
 
     double effectivePotential() override;

--- a/include/common.h
+++ b/include/common.h
@@ -274,6 +274,8 @@ void printError(const std::string& msg, int this_rank, const std::string& err_ty
 // Print a progress bar
 void printProgress(int this_step, int total_steps, int this_rank, int out_rank = 0);
 
+dVec getSeparation(int first_ptcl, int second_ptcl, bool minimum_image, bool pbc, dVec& coord, double size);
+
 // To handle periodic boundary conditions, we employ the Class C storage
 // concept [Z. Phys. Chem. 227 (2013) 345-352], allowing atoms to move
 // outside the primary simulation box. That is, the coordinates are not folded

--- a/include/normal_modes.h
+++ b/include/normal_modes.h
@@ -10,7 +10,7 @@ class NormalModes {
 public:
     NormalModes(Params& param_obj, int this_bead, dVec& coord, dVec& momenta);
     ~NormalModes();
-    std::vector<double> arr_coord_cartesian, arr_coord_nm, arr_momenta_cartesian, arr_momenta_nm;  // Arrays that contain the coordinates and momenta of the WHOLE system in two representations
+    double *arr_coord_cartesian, *arr_coord_nm, *arr_momenta_cartesian, *arr_momenta_nm;  // Arrays that contain the coordinates and momenta of the WHOLE system in two representations
     std::vector<double> cart_to_nm_mat_row, nm_to_cart_mat_row;
     void shareData();
     double coordCarToNM(const int glob_idx);

--- a/include/normal_modes.h
+++ b/include/normal_modes.h
@@ -2,14 +2,15 @@
 
 #include <vector>
 #include "mpi.h"
+#include "common.h"
 
-class Simulation;
+class Params;
 
 class NormalModes {
 public:
-    NormalModes(Simulation& _sim);
+    NormalModes(Params& param_obj, int this_bead, dVec& coord, dVec& momenta);
     ~NormalModes();
-    double *arr_coord_cartesian, *arr_coord_nm, *arr_momenta_cartesian, *arr_momenta_nm;  // Arrays that contain the coordinates and momenta of the WHOLE system in two representations
+    std::vector<double> arr_coord_cartesian, arr_coord_nm, arr_momenta_cartesian, arr_momenta_nm;  // Arrays that contain the coordinates and momenta of the WHOLE system in two representations
     std::vector<double> cart_to_nm_mat_row, nm_to_cart_mat_row;
     void shareData();
     double coordCarToNM(const int glob_idx);
@@ -22,5 +23,7 @@ private:
     int axis_stride, atom_stride;  // For indexing purposes
     MPI_Win win_coord_cartesian, win_coord_nm, win_momenta_cartesian, win_momenta_nm;     // Window objects associated with the arrays
     int globIndexBead(int axis, int atom, int bead) const { return globIndexAtom(axis, atom) + bead; }
-    Simulation& sim; // Reference to the simulation object
+    int natoms, nbeads, this_bead;
+    dVec& coord;
+    dVec& momenta;
 };

--- a/include/observables.h
+++ b/include/observables.h
@@ -2,6 +2,6 @@
 
 #include "observables/observable.h"
 #include "observables/bosonic.h"
-#include "observables/energy.h"
+#include "observables/quantum.h"
 #include "observables/classical.h"
 #include "observables/gsf_action.h"

--- a/include/observables/bosonic.h
+++ b/include/observables/bosonic.h
@@ -2,13 +2,16 @@
 
 #include "observables/observable.h"
 
-class Simulation; // Forward declaration
+class BosonicExchangeBase; // Forward declaration
 
 /* -------------------------------- */
 
 class BosonicObservable : public Observable {
 public:
-    BosonicObservable(const Simulation& _sim, int _freq, const std::string& _out_unit);
+    BosonicObservable(Params& param_obj, int _freq, const std::string& _out_unit, int this_bead, BosonicExchangeBase& bosonic_exchange);
 
     void calculate() override;
+private:
+    bool bosonic;
+    BosonicExchangeBase& bosonic_exchange;
 };

--- a/include/observables/classical.h
+++ b/include/observables/classical.h
@@ -1,18 +1,22 @@
 #pragma once
 
-#include "observables/observable.h"
+#include "observables/energy.h"
 
-class Simulation; // Forward declaration
+class Thermostat; // Forward declaration
 
 /* -------------------------------- */
 
-class ClassicalObservable : public Observable {
+class ClassicalObservable : public EnergyObservable {
 public:
-    ClassicalObservable(const Simulation& _sim, int _freq, const std::string& _out_unit);
+    ClassicalObservable(Params& param_obj, int _freq, const std::string& _out_unit, int this_bead, 
+                        dVec& prev_coord, dVec& coord, BosonicExchangeBase& bosonic_exchange, Thermostat& thermostat, dVec& momenta);
 
     void calculate() override;
 
 private:
     void calculateKineticEnergy();
     void calculateSpringEnergy();
+    std::string thermostat_type;
+    Thermostat& thermostat;
+    dVec& momenta;
 };

--- a/include/observables/energy.h
+++ b/include/observables/energy.h
@@ -1,18 +1,28 @@
 #pragma once
 
 #include "observables/observable.h"
+#include "common.h"
 
-class Simulation; // Forward declaration
-
+class BosonicExchangeBase; // Forward declaration
 /* -------------------------------- */
 
 class EnergyObservable : public Observable {
 public:
-    EnergyObservable(const Simulation& _sim, int _freq, const std::string& _out_unit);
+    EnergyObservable(Params& param_obj, int _freq, const std::string& _out_unit, int this_bead, 
+                     dVec& prev_coord, dVec& coord, BosonicExchangeBase& bosonic_exchange);
 
     void calculate() override;
 
-private:
-    void calculateKinetic();
-    void calculatePotential();
+protected:
+    double classicalSpringEnergy() const;
+    int nbeads;
+    int natoms;
+    bool bosonic;
+    bool pbc;
+    double spring_constant;
+    double size;
+    double mass;
+    dVec& prev_coord;
+    dVec& coord;
+    BosonicExchangeBase& bosonic_exchange;
 };

--- a/include/observables/gsf_action.h
+++ b/include/observables/gsf_action.h
@@ -1,14 +1,23 @@
 #pragma once
 
 #include "observables/observable.h"
-
-class Simulation; // Forward declaration
+#include "common.h"
+class Potential;
 
 /* -------------------------------- */
 
 class GSFActionObservable : public Observable {
 public:
-    GSFActionObservable(const Simulation& _sim, int _freq, const std::string& _out_unit);
+    GSFActionObservable(Params& param_obj, int _freq, const std::string& _out_unit, int this_bead,
+                        Potential& ext_potential, Potential& int_potential, dVec& coord);
 
     void calculate() override;
+private:
+    double beta, spring_constant;
+    Potential& ext_potential;
+    Potential& int_potential;
+    dVec& coord;
+    int natoms, nbeads;
+    double int_pot_cutoff, size;
+    bool pbc;
 };

--- a/include/observables/observable.h
+++ b/include/observables/observable.h
@@ -4,16 +4,17 @@
 #include <memory>
 #include <vector>
 #include <fstream>
-
+#include "params.h"
 #include "ordered_map.h"
 
+class Params; // Forward declaration
 class Simulation; // Forward declaration
 
 /* -------------------------------- */
 
 class Observable {
 public:
-    explicit Observable(const Simulation& _sim, int _freq, const std::string& _out_unit);
+    explicit Observable(Params& param_obj, int _freq, const std::string& _out_unit, int this_bead);
     virtual void calculate() = 0;
     virtual ~Observable() = default;
 
@@ -23,17 +24,17 @@ public:
     tsl::ordered_map<std::string, double> quantities;
 
 protected:
-    const Simulation& sim; // Reference to the simulation object
     int freq;              // Frequency at which the observable is recorded
     std::string out_unit;  // Units of the output quantities
+    int this_bead;
 };
 
 /* -------------------------------- */
 
 class ObservableFactory {
 public:
-    static std::unique_ptr<Observable> createQuantity(const std::string& observable_type, const Simulation& _sim, int _freq,
-        const std::string& _out_unit);
+    static std::unique_ptr<Observable> createQuantity(Simulation& sim, Params& param_obj, const std::string& observable_type, int _freq,
+        const std::string& _out_unit, int this_bead);
 };
 
 /* -------------------------------- */

--- a/include/observables/quantum.h
+++ b/include/observables/quantum.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "observables/energy.h"
+
+class Potential;
+
+/* -------------------------------- */
+
+class QuantumObservable : public EnergyObservable {
+public:
+    QuantumObservable(Params& param_obj, int _freq, const std::string& _out_unit, int this_bead, 
+                      dVec& prev_coord, dVec& coord, BosonicExchangeBase& bosonic_exchange,
+                      Potential& ext_potential, Potential& int_potential, dVec& physical_forces);
+
+    void calculate() override;
+
+private:
+    void calculateKinetic();
+    void calculatePotential();
+    std::string external_potential_name;
+    std::string interaction_potential_name;
+    double beta;
+    Potential& ext_potential;
+    Potential& int_potential;
+    dVec& physical_forces;
+};

--- a/include/propagators.h
+++ b/include/propagators.h
@@ -1,4 +1,4 @@
 #pragma once
 
-#include "propagators/velocity_verlet.h"
+#include "propagators/cartesian_propagator.h"
 #include "propagators/normal_modes_propagator.h"

--- a/include/propagators/cartesian_propagator.h
+++ b/include/propagators/cartesian_propagator.h
@@ -2,10 +2,10 @@
 
 #include "propagators/propagator.h"
 
-class VelocityVerletPropagator : public Propagator {
+class CartesianPropagator : public Propagator {
 public:
-    VelocityVerletPropagator(Params& param_obj, dVec& coord, dVec& momenta, dVec& forces);
-    ~VelocityVerletPropagator() override = default;
+    CartesianPropagator(Params& param_obj, dVec& coord, dVec& momenta, dVec& forces);
+    ~CartesianPropagator() override = default;
 
     void preForceStep() override;
     void postForceStep() override;

--- a/include/propagators/cartesian_propagator.h
+++ b/include/propagators/cartesian_propagator.h
@@ -2,11 +2,9 @@
 
 #include "propagators/propagator.h"
 
-class Simulation;
-
 class VelocityVerletPropagator : public Propagator {
 public:
-    VelocityVerletPropagator(Simulation& _sim, Params& param_obj, dVec& coord, dVec& momenta, dVec& forces);
+    VelocityVerletPropagator(Params& param_obj, dVec& coord, dVec& momenta, dVec& forces);
     ~VelocityVerletPropagator() override = default;
 
     void preForceStep() override;

--- a/include/propagators/normal_modes_propagator.h
+++ b/include/propagators/normal_modes_propagator.h
@@ -10,7 +10,8 @@ public:
     NormalModesPropagator(Simulation& _sim);
     ~NormalModesPropagator() override = default;
 
-    void step() override;
+    void preForceStep() override;
+    void postForceStep() override;
 
 private:
     double freq, c, s, m_omega;

--- a/include/propagators/normal_modes_propagator.h
+++ b/include/propagators/normal_modes_propagator.h
@@ -7,7 +7,7 @@ class NormalModes;
 
 class NormalModesPropagator : public Propagator {
 public:
-    NormalModesPropagator(Simulation& _sim, Params& param_obj, dVec& coord, dVec& momenta, dVec& forces, dVec& ext_forces, dVec& spring_forces);
+    NormalModesPropagator(Simulation& _sim, Params& param_obj, dVec& coord, dVec& momenta, dVec& forces, dVec& physical_forces, dVec& spring_forces);
     ~NormalModesPropagator() override = default;
 
     void preForceStep() override;
@@ -15,7 +15,7 @@ public:
 
 private:
     double freq, c, s, m_omega;
-    dVec& ext_forces;
+    dVec& physical_forces;
     dVec& spring_forces;
     void momentaExternalForces();
 };

--- a/include/propagators/normal_modes_propagator.h
+++ b/include/propagators/normal_modes_propagator.h
@@ -7,7 +7,7 @@ class NormalModes;
 
 class NormalModesPropagator : public Propagator {
 public:
-    NormalModesPropagator(Simulation& _sim);
+    NormalModesPropagator(Simulation& _sim, Params& param_obj, dVec& coord, dVec& momenta, dVec& forces);
     ~NormalModesPropagator() override = default;
 
     void preForceStep() override;

--- a/include/propagators/normal_modes_propagator.h
+++ b/include/propagators/normal_modes_propagator.h
@@ -7,7 +7,7 @@ class NormalModes;
 
 class NormalModesPropagator : public Propagator {
 public:
-    NormalModesPropagator(Simulation& _sim, Params& param_obj, dVec& coord, dVec& momenta, dVec& forces);
+    NormalModesPropagator(Simulation& _sim, Params& param_obj, dVec& coord, dVec& momenta, dVec& forces, dVec& ext_forces, dVec& spring_forces);
     ~NormalModesPropagator() override = default;
 
     void preForceStep() override;
@@ -15,6 +15,7 @@ public:
 
 private:
     double freq, c, s, m_omega;
-    dVec ext_forces, spring_forces;
+    dVec& ext_forces;
+    dVec& spring_forces;
     void momentaExternalForces();
 };

--- a/include/propagators/normal_modes_propagator.h
+++ b/include/propagators/normal_modes_propagator.h
@@ -2,12 +2,13 @@
 
 #include "propagators/propagator.h"
 
-class Simulation;
 class NormalModes;
 
 class NormalModesPropagator : public Propagator {
 public:
-    NormalModesPropagator(Simulation& _sim, Params& param_obj, dVec& coord, dVec& momenta, dVec& forces, dVec& physical_forces, dVec& spring_forces);
+    NormalModesPropagator(Params& param_obj, dVec& coord, dVec& momenta, dVec& forces, 
+                          dVec& physical_forces, dVec& spring_forces, dVec& prev_coord, dVec& next_coord,
+                          int this_bead, NormalModes& normal_modes);
     ~NormalModesPropagator() override = default;
 
     void preForceStep() override;
@@ -17,5 +18,13 @@ private:
     double freq, c, s, m_omega;
     dVec& physical_forces;
     dVec& spring_forces;
+    dVec& prev_coord;
+    dVec& next_coord;
+
+    int this_bead, nbeads;
+    double spring_constant;
+    NormalModes& normal_modes;
+    bool bosonic;
+
     void momentaExternalForces();
 };

--- a/include/propagators/propagator.h
+++ b/include/propagators/propagator.h
@@ -9,9 +9,8 @@ public:
     explicit Propagator(Simulation& _sim);
     virtual ~Propagator() = default;
     
-    virtual void step() = 0;
-    void momentStep();
-    void coordsStep();
+    virtual void preForceStep() = 0;
+    virtual void postForceStep() = 0;
 
 protected:
     Simulation& sim; // Reference to the simulation object

--- a/include/propagators/propagator.h
+++ b/include/propagators/propagator.h
@@ -2,19 +2,17 @@
 
 #include "common.h"
 
-class Simulation;
 class Params;
 
 class Propagator {
 public:
-    explicit Propagator(Simulation& _sim, Params& param_obj, dVec& coord, dVec& momenta, dVec& forces);
+    explicit Propagator(Params& param_obj, dVec& coord, dVec& momenta, dVec& forces);
     virtual ~Propagator() = default;
     
     virtual void preForceStep() = 0;
     virtual void postForceStep() = 0;
 
 protected:
-    Simulation& sim; // Reference to the simulation object
     dVec& coord;
     dVec& momenta;
     dVec& forces;

--- a/include/propagators/propagator.h
+++ b/include/propagators/propagator.h
@@ -3,10 +3,11 @@
 #include "common.h"
 
 class Simulation;
+class Params;
 
 class Propagator {
 public:
-    explicit Propagator(Simulation& _sim);
+    explicit Propagator(Simulation& _sim, Params& param_obj, dVec& coord, dVec& momenta, dVec& forces);
     virtual ~Propagator() = default;
     
     virtual void preForceStep() = 0;
@@ -14,4 +15,10 @@ public:
 
 protected:
     Simulation& sim; // Reference to the simulation object
+    dVec& coord;
+    dVec& momenta;
+    dVec& forces;
+    int natoms;
+    double mass;
+    double dt;
 };

--- a/include/propagators/velocity_verlet.h
+++ b/include/propagators/velocity_verlet.h
@@ -10,4 +10,7 @@ public:
     ~VelocityVerletPropagator() override = default;
 
     void step() override;
+private:
+    void momentStep();
+    void coordsStep();
 };

--- a/include/propagators/velocity_verlet.h
+++ b/include/propagators/velocity_verlet.h
@@ -9,7 +9,8 @@ public:
     VelocityVerletPropagator(Simulation& _sim);
     ~VelocityVerletPropagator() override = default;
 
-    void step() override;
+    void preForceStep() override;
+    void postForceStep() override;
 private:
     void momentStep();
     void coordsStep();

--- a/include/propagators/velocity_verlet.h
+++ b/include/propagators/velocity_verlet.h
@@ -6,7 +6,7 @@ class Simulation;
 
 class VelocityVerletPropagator : public Propagator {
 public:
-    VelocityVerletPropagator(Simulation& _sim);
+    VelocityVerletPropagator(Simulation& _sim, Params& param_obj, dVec& coord, dVec& momenta, dVec& forces);
     ~VelocityVerletPropagator() override = default;
 
     void preForceStep() override;

--- a/include/simulation.h
+++ b/include/simulation.h
@@ -55,7 +55,7 @@ public:
     Simulation(const int& rank, const int& nproc, Params& param_obj, unsigned int seed = static_cast<unsigned int>(time(nullptr)));
     ~Simulation();
 
-    dVec coord, momenta, forces;
+    dVec coord, momenta, forces, spring_forces, physical_forces;
     dVec prev_coord, next_coord;
 
     int getStep() const;
@@ -102,8 +102,8 @@ public:
     std::string interaction_potential_name;
 
     void updateForces();
-    void updateSpringForces(dVec& spring_force_arr) const;
-    void updatePhysicalForces(dVec& physical_force_arr) const;
+    void updateSpringForces();
+    void updatePhysicalForces();
 
     double classicalSpringEnergy() const;
 

--- a/include/simulation.h
+++ b/include/simulation.h
@@ -79,13 +79,13 @@ public:
     void initializeMomenta(dVec& momentum_arr, const VariantMap& sim_params);
     void addStateIfEnabled(Params& param_obj, const std::string& param_key, const std::string& state_name);
     void initializeStates(Params& param_obj);
-    void addObservableIfEnabled(const StringMap& sim_params, const std::string& param_key, const std::string& observable_name);
-    void initializeObservables(const StringMap& sim_params);
+    void addObservableIfEnabled(Params& param_obj, const std::string& param_key, const std::string& observable_name);
+    void initializeObservables(Params& param_obj);
     std::unique_ptr<Potential> initializePotential(const std::string& potential_name,
                                                    const VariantMap& potential_options);
 
     double sampleMaxwellBoltzmann();
-    
+    double classicalSpringEnergy() const;
     std::unique_ptr<Propagator> propagator;
     std::unique_ptr<Thermostat> thermostat;
     std::unique_ptr<Coupling> thermostat_coupling;
@@ -105,13 +105,9 @@ public:
     void updateSpringForces();
     void updatePhysicalForces();
 
-    double classicalSpringEnergy() const;
-
     void getNextCoords(dVec& next);
     void getPrevCoords(dVec& prev);
     void updateNeighboringCoordinates();
-
-    dVec getSeparation(int first_ptcl, int second_ptcl, bool minimum_image = false) const;
 
     int this_bead;   // Current process id ("rank" of MPI_Comm_rank)
     int nproc;       // Number of processes ("size" of MPI_Comm_size)

--- a/include/simulation.h
+++ b/include/simulation.h
@@ -74,7 +74,7 @@ public:
 
     void initializePropagator(Params& param_obj);
     void initializeThermostat(Params& param_obj);
-    void initializeExchangeAlgorithm();
+    void initializeExchangeAlgorithm(Params& param_obj);
     void initializePositions(dVec& coord_arr, const VariantMap& sim_params);
     void initializeMomenta(dVec& momentum_arr, const VariantMap& sim_params);
     void addStateIfEnabled(Params& param_obj, const std::string& param_key, const std::string& state_name);

--- a/include/simulation.h
+++ b/include/simulation.h
@@ -77,8 +77,8 @@ public:
     void initializeExchangeAlgorithm();
     void initializePositions(dVec& coord_arr, const VariantMap& sim_params);
     void initializeMomenta(dVec& momentum_arr, const VariantMap& sim_params);
-    void addStateIfEnabled(const StringMap& sim_params, const std::string& param_key, const std::string& state_name);
-    void initializeStates(const StringMap& sim_params);
+    void addStateIfEnabled(Params& param_obj, const std::string& param_key, const std::string& state_name);
+    void initializeStates(Params& param_obj);
     void addObservableIfEnabled(const StringMap& sim_params, const std::string& param_key, const std::string& observable_name);
     void initializeObservables(const StringMap& sim_params);
     std::unique_ptr<Potential> initializePotential(const std::string& potential_name,

--- a/include/simulation.h
+++ b/include/simulation.h
@@ -72,7 +72,7 @@ public:
 
     void zeroMomentum();
 
-    void initializePropagator(const VariantMap& sim_params);
+    void initializePropagator(Params& param_obj);
     void initializeThermostat(Params& param_obj);
     void initializeExchangeAlgorithm();
     void initializePositions(dVec& coord_arr, const VariantMap& sim_params);

--- a/include/simulation.h
+++ b/include/simulation.h
@@ -5,7 +5,6 @@
 #include <ctime>
 #include <memory>
 
-#include "random_mars.h"
 #include "common.h"
 #include "params.h"
 #include "potentials.h"
@@ -16,6 +15,7 @@ class State;
 class Observable;
 class Propagator;
 class Thermostat;
+class Coupling;
 
 class Simulation
 {
@@ -51,7 +51,6 @@ public:
     std::vector<std::unique_ptr<State>> states;
 
     std::mt19937 rand_gen;
-    std::unique_ptr<RanMars> mars_gen;
 
     Simulation(const int& rank, const int& nproc, Params& param_obj, unsigned int seed = static_cast<unsigned int>(time(nullptr)));
     ~Simulation();
@@ -74,7 +73,7 @@ public:
     void zeroMomentum();
 
     void initializePropagator(const VariantMap& sim_params);
-    void initializeThermostat(const VariantMap& sim_params);
+    void initializeThermostat(Params& param_obj);
     void initializeExchangeAlgorithm();
     void initializePositions(dVec& coord_arr, const VariantMap& sim_params);
     void initializeMomenta(dVec& momentum_arr, const VariantMap& sim_params);
@@ -89,6 +88,7 @@ public:
     
     std::unique_ptr<Propagator> propagator;
     std::unique_ptr<Thermostat> thermostat;
+    std::unique_ptr<Coupling> thermostat_coupling;
 
     std::unique_ptr<NormalModes> normal_modes;
 

--- a/include/states/force.h
+++ b/include/states/force.h
@@ -2,12 +2,14 @@
 
 #include "states/state.h"
 
-class Simulation; // Forward declaration
+class Params; // Forward declaration
 
 class ForceState : public State {
 public:
-    ForceState(const Simulation& _sim, int _freq, const std::string& _out_unit);
+    ForceState(Params& param_obj, int _freq, const std::string& _out_unit, dVec& _forces);
 
-    void initialize() override;
+    void initialize(int this_bead) override;
     void output(int step) override;
+private:
+    dVec& forces;
 };

--- a/include/states/position.h
+++ b/include/states/position.h
@@ -2,12 +2,12 @@
 
 #include "states/state.h"
 
-class Simulation; // Forward declaration
-
 class PositionState : public State {
 public:
-    PositionState(const Simulation& _sim, int _freq, const std::string& _out_unit);
+    PositionState(Params& param_obj, int _freq, const std::string& _out_unit, dVec& coords);
 
-    void initialize() override;
+    void initialize(int this_bead) override;
     void output(int step) override;
+private:
+    dVec& coord;
 };

--- a/include/states/state.h
+++ b/include/states/state.h
@@ -3,24 +3,26 @@
 #include <string>
 #include <memory>
 #include <fstream>
+#include "common.h"
 
+class Params; // Forward declaration
 class Simulation; // Forward declaration
 
 /* -------------------------------- */
 
 class State {
 public:
-    explicit State(const Simulation& _sim, int _freq, const std::string& _out_unit);
+    explicit State(Params& param_obj, int _freq, const std::string& _out_unit);
     ~State();
 
-    virtual void initialize() = 0;
+    virtual void initialize(int this_bead) = 0;
     virtual void output(int step) = 0;   
 
 protected:
-    const Simulation& sim;   // Reference to the simulation object
     int freq;                // Frequency at which the state is recorded
     std::ofstream out_file;  // Output file stream
     std::string out_unit;    // Units of the output quantities
+    int natoms, nbeads;
 };
 
 /* -------------------------------- */
@@ -28,5 +30,5 @@ protected:
 class StateFactory {
 public:
     static std::unique_ptr<State> createQuantity(const std::string& state_type, 
-        const Simulation& _sim, int _freq, const std::string& _out_unit);
+        Simulation& sim, Params& param_obj, int _freq, const std::string& _out_unit);
 };

--- a/include/states/velocity.h
+++ b/include/states/velocity.h
@@ -2,12 +2,13 @@
 
 #include "states/state.h"
 
-class Simulation; // Forward declaration
-
 class VelocityState : public State {
 public:
-    VelocityState(const Simulation& _sim, int _freq, const std::string& _out_unit);
+    VelocityState(Params& param_obj, int _freq, const std::string& _out_unit, dVec& momenta);
 
-    void initialize() override;
+    void initialize(int this_bead) override;
     void output(int step) override;
+private:
+    double mass;
+    dVec& momenta;
 };

--- a/include/thermostats/langevin.h
+++ b/include/thermostats/langevin.h
@@ -3,17 +3,19 @@
 #include <vector>
 #include <memory>
 #include "thermostats/thermostat.h"
+#include "random_mars.h"
 
 class Simulation;
 class Coupling;
 
 class LangevinThermostat : public Thermostat {
 public:
-    LangevinThermostat(Simulation& _sim, bool normal_modes);
+    LangevinThermostat(Coupling& coupling, Params& param_obj, int rank);
     ~LangevinThermostat() override = default;
 
     void momentaUpdate() override;
 
-protected:
+private:
     double friction_coefficient, noise_coefficient;
+    std::unique_ptr<RanMars> mars_gen;
 };

--- a/include/thermostats/nose_hoover.h
+++ b/include/thermostats/nose_hoover.h
@@ -10,7 +10,7 @@ class Coupling;
 
 class NoseHooverThermostat : public Thermostat {
 public:
-    NoseHooverThermostat(Simulation& _sim, bool normal_modes, int _nchains);
+    NoseHooverThermostat(Coupling& coupling, Params& param_obj);
     ~NoseHooverThermostat() override = default;
 
     void momentaUpdate() override;
@@ -30,7 +30,7 @@ protected:
 
 class NoseHooverNpThermostat : public NoseHooverThermostat {
 public:
-    NoseHooverNpThermostat(Simulation& _sim, bool normal_modes, int _nchains);
+    NoseHooverNpThermostat(Coupling& coupling, Params& param_obj);
     ~NoseHooverNpThermostat() override = default;
 
     void momentaUpdate() override;
@@ -41,7 +41,7 @@ public:
 
 class NoseHooverNpDimThermostat : public NoseHooverThermostat {
 public:
-    NoseHooverNpDimThermostat(Simulation& _sim, bool normal_modes, int _nchains);
+    NoseHooverNpDimThermostat(Coupling& coupling, Params& param_obj);
     ~NoseHooverNpDimThermostat() override = default;
 
     void momentaUpdate() override;

--- a/include/thermostats/thermostat.h
+++ b/include/thermostats/thermostat.h
@@ -2,18 +2,23 @@
 
 #include <vector>
 #include <memory>
+#include "params.h"
 
-class Simulation;
 class Coupling;
 
 class Thermostat {
 public:
-    explicit Thermostat(Simulation& _sim, bool normal_modes);
+    explicit Thermostat(Coupling& coupling, Params& param_obj);
     virtual ~Thermostat() = default;
     void step();
     virtual void momentaUpdate();
     virtual double getAdditionToH();
 protected:
-    Simulation& sim;   // Reference to the simulation object
-    std::unique_ptr<Coupling> coupling;
+    Coupling& coupling;
+    int natoms;
+    double mass;
+    double dt;
+    int nbeads;
+    double beta;
+    double thermo_beta;
 };

--- a/include/thermostats/thermostat_coupling.h
+++ b/include/thermostats/thermostat_coupling.h
@@ -1,11 +1,12 @@
+#include "common.h"
 #pragma once
 
-class Simulation;
+class NormalModes;
 
 // Classes to support coupling of the thermostat to Cartesian coords or normal modes of distinguishable ring polymers
 class Coupling {
 public:
-    explicit Coupling(Simulation& _sim);
+    explicit Coupling(dVec& _momenta);
     virtual ~Coupling() = default;
 
     virtual void mpiCommunication() = 0;
@@ -13,12 +14,12 @@ public:
     virtual double& getMomentumForUpdate(const int ptcl_idx, const int axis) = 0;
     virtual void updateCoupledMomenta() = 0;
 protected:
-    Simulation& sim;
+    dVec& momenta;
 };
 
 class CartesianCoupling : public Coupling {
 public:
-    CartesianCoupling(Simulation& _sim);
+    CartesianCoupling(dVec& _momenta);
     virtual ~CartesianCoupling() = default;
 
     void mpiCommunication() override;
@@ -29,11 +30,14 @@ public:
 
 class NMCoupling : public Coupling {
 public:
-    NMCoupling(Simulation& _sim);
+    NMCoupling(dVec& _momenta, NormalModes& normal_modes, int this_bead);
     virtual ~NMCoupling() = default;
 
     void mpiCommunication() override;
     double getMomentumForCalc(const int ptcl_idx, const int axis) override;
     double& getMomentumForUpdate(const int ptcl_idx, const int axis) override;
     void updateCoupledMomenta() override;
+private:
+    NormalModes& normal_modes;
+    int this_bead;
 };

--- a/src/bosonic_exchange/factorial_bosonic_exchange.cpp
+++ b/src/bosonic_exchange/factorial_bosonic_exchange.cpp
@@ -125,6 +125,13 @@ void FactorialBosonicExchange::springForceLastBead(dVec& f) {
     dVec temp_force(nbosons);
     double denom_weight = 0.0;
 
+    // Zero the spring forces
+    for (int ptcl_one = 0; ptcl_one < natoms; ++ptcl_one) {
+        for (int axis = 0; axis < NDIM; ++axis) {
+            f(ptcl_one, axis) = 0.;
+        }
+    }
+    
     do {
         double weight = 0.0;
 
@@ -182,6 +189,13 @@ void FactorialBosonicExchange::springForceFirstBead(dVec& f) {
 
     dVec temp_force(nbosons);
     double denom_weight = 0.0;
+
+    // Zero the spring forces
+    for (int ptcl_one = 0; ptcl_one < natoms; ++ptcl_one) {
+        for (int axis = 0; axis < NDIM; ++axis) {
+            f(ptcl_one, axis) = 0.;
+        }
+    }
 
     do {
         double weight = 0.0;

--- a/src/bosonic_exchange/factorial_bosonic_exchange.cpp
+++ b/src/bosonic_exchange/factorial_bosonic_exchange.cpp
@@ -126,12 +126,12 @@ void FactorialBosonicExchange::springForceLastBead(dVec& f) {
     double denom_weight = 0.0;
 
     // Zero the spring forces
-    for (int ptcl_one = 0; ptcl_one < natoms; ++ptcl_one) {
+    for (int ptcl_one = 0; ptcl_one < sim.natoms; ++ptcl_one) {
         for (int axis = 0; axis < NDIM; ++axis) {
             f(ptcl_one, axis) = 0.;
         }
     }
-    
+
     do {
         double weight = 0.0;
 
@@ -191,7 +191,7 @@ void FactorialBosonicExchange::springForceFirstBead(dVec& f) {
     double denom_weight = 0.0;
 
     // Zero the spring forces
-    for (int ptcl_one = 0; ptcl_one < natoms; ++ptcl_one) {
+    for (int ptcl_one = 0; ptcl_one < sim.natoms; ++ptcl_one) {
         for (int axis = 0; axis < NDIM; ++axis) {
             f(ptcl_one, axis) = 0.;
         }

--- a/src/bosonic_exchange/factorial_bosonic_exchange.cpp
+++ b/src/bosonic_exchange/factorial_bosonic_exchange.cpp
@@ -127,7 +127,7 @@ void FactorialBosonicExchange::springForceLastBead(dVec& f) {
     double denom_weight = 0.0;
 
     // Zero the spring forces
-    for (int ptcl_one = 0; ptcl_one < sim.natoms; ++ptcl_one) {
+    for (int ptcl_one = 0; ptcl_one < nbosons; ++ptcl_one) {
         for (int axis = 0; axis < NDIM; ++axis) {
             f(ptcl_one, axis) = 0.;
         }
@@ -192,7 +192,7 @@ void FactorialBosonicExchange::springForceFirstBead(dVec& f) {
     double denom_weight = 0.0;
 
     // Zero the spring forces
-    for (int ptcl_one = 0; ptcl_one < sim.natoms; ++ptcl_one) {
+    for (int ptcl_one = 0; ptcl_one < nbosons; ++ptcl_one) {
         for (int axis = 0; axis < NDIM; ++axis) {
             f(ptcl_one, axis) = 0.;
         }

--- a/src/bosonic_exchange/factorial_bosonic_exchange.cpp
+++ b/src/bosonic_exchange/factorial_bosonic_exchange.cpp
@@ -3,9 +3,10 @@
 #include <algorithm>
 
 #include "bosonic_exchange/factorial_bosonic_exchange.h"
-#include "simulation.h"
 
-FactorialBosonicExchange::FactorialBosonicExchange(const Simulation& _sim) : BosonicExchangeBase(_sim), labels(_sim.natoms) {
+FactorialBosonicExchange::FactorialBosonicExchange(Params& param_obj, 
+                const dVec& coord, const dVec& prev_coord, const dVec& next_coord, const int this_bead) : 
+    BosonicExchangeBase(param_obj, coord, prev_coord, next_coord, this_bead), labels(nbosons) {
     // Fill the labels array with numbers from 0 to nbosons-1
     std::iota(labels.begin(), labels.end(), 0);
 
@@ -107,7 +108,7 @@ double FactorialBosonicExchange::effectivePotential() {
             diff2 += getBeadsSeparationSquared(x_first_bead, ptcl_idx, x_last_bead, lastBeadNeighbor(ptcl_idx));
         }
 
-        weights_sum += exp(-sim.beta_half_k * diff2);
+        weights_sum += exp(-beta * 0.5 * spring_constant * diff2);
     } while (std::ranges::next_permutation(labels).found);
 
     return (-1.0 / beta) * log(weights_sum / permutation_counter);

--- a/src/bosonic_exchange/quadratic_bosonic_exchange.cpp
+++ b/src/bosonic_exchange/quadratic_bosonic_exchange.cpp
@@ -3,9 +3,9 @@
 #include <cmath>
 
 #include "bosonic_exchange/quadratic_bosonic_exchange.h"
-#include "simulation.h"
 
-BosonicExchange::BosonicExchange(const Simulation& _sim) : BosonicExchangeBase(_sim),
+BosonicExchange::BosonicExchange(Params& param_obj, const dVec& coord, const dVec& prev_coord, const dVec& next_coord, const int this_bead) : 
+    BosonicExchangeBase(param_obj, coord, prev_coord, next_coord, this_bead),
     E_kn(nbosons * (nbosons + 1) / 2),
     V(nbosons + 1),
     V_backwards(nbosons + 1),
@@ -279,11 +279,9 @@ double BosonicExchange::primEstimator() {
 }
 
 void BosonicExchange::printBosonicDebug() {
-    if (sim.this_bead == 0) {
+    if (this_bead == 0) {
         std::ofstream debug;
         debug.open(std::format("{}/bosonic_debug.log", Output::FOLDER_NAME), std::ios::out | std::ios::app);
-
-        debug << "Step " << sim.getStep() << '\n';
 
         debug << "Bosonic energies:\n";
         for (int m = 1; m < nbosons + 1; ++m) {

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -38,6 +38,32 @@ void printProgress(int this_step, int total_steps, int this_rank, int out_rank) 
     }
 }
 
+/**
+ * Returns the vectorial distance between two particles at the same imaginary timeslice.
+ * Mathematically equivalent to r1-r2, where r1 and r2 are the position-vectors
+ * of the first and second particles, respectively. In the case of PBC, there is an
+ * option to return the minimal distance between the two particles.
+ * 
+ * @param first_ptcl Index of the first particle.
+ * @param second_ptcl Index of the second particle.
+ * @param minimum_image Flag determining whether the minimum image convention should be applied.
+ * @return Vectorial distance between the two particles.
+ */
+dVec getSeparation(int first_ptcl, int second_ptcl, bool minimum_image, bool pbc, dVec& coord, double size) {
+    dVec sep;
+
+    for (int axis = 0; axis < NDIM; ++axis) {
+        double diff = coord(first_ptcl, axis) - coord(second_ptcl, axis);
+
+        if (pbc && minimum_image)
+            applyMinimumImage(diff, size);
+
+        sep(0, axis) = diff;
+    }
+
+    return sep;
+}
+
 void applyMinimumImage(double& dx, double L) {
     dx -= L * floor(dx / L + 0.5);
 }

--- a/src/observables/bosonic.cpp
+++ b/src/observables/bosonic.cpp
@@ -1,13 +1,14 @@
 #include "observables/bosonic.h"
-#include "simulation.h"
+#include "bosonic_exchange.h"
 #include <ranges>
-#include "mpi.h"
 
 /**
  * @brief Bosonic observable class constructor.
  */
-BosonicObservable::BosonicObservable(const Simulation& _sim, int _freq, const std::string& _out_unit) :
-    Observable(_sim, _freq, _out_unit) {
+BosonicObservable::BosonicObservable(Params& param_obj, int _freq, const std::string& _out_unit, 
+                                     int this_bead, BosonicExchangeBase& bosonic_exchange) :
+    Observable(param_obj, _freq, _out_unit, this_bead), bosonic_exchange(bosonic_exchange) {
+    getVariant(param_obj.sim["bosonic"], bosonic);
     initialize({ "prob_dist", "prob_all" });
 }
 
@@ -15,8 +16,8 @@ BosonicObservable::BosonicObservable(const Simulation& _sim, int _freq, const st
  * @brief Calculates quantities pertaining to bosonic exchange.
  */
 void BosonicObservable::calculate() {
-    if (sim.this_bead == 0 && sim.bosonic) {
-        quantities["prob_dist"] = sim.bosonic_exchange->getDistinctProbability();
-        quantities["prob_all"] = sim.bosonic_exchange->getLongestProbability();
+    if (this_bead == 0 && bosonic) {
+        quantities["prob_dist"] = bosonic_exchange.getDistinctProbability();
+        quantities["prob_all"] = bosonic_exchange.getLongestProbability();
     }
 }

--- a/src/observables/classical.cpp
+++ b/src/observables/classical.cpp
@@ -1,16 +1,20 @@
 #include "observables/classical.h"
-#include "simulation.h"
 #include "thermostats.h"
+#include "bosonic_exchange.h"
 #include "units.h"
 #include <ranges>
-#include "mpi.h"
+#include <iostream>
 
 /**
  * @brief Classical observable class constructor.
  */
-ClassicalObservable::ClassicalObservable(const Simulation& _sim, int _freq, const std::string& _out_unit) :
-    Observable(_sim, _freq, _out_unit) {
-    if (sim.thermostat_type == "nose_hoover" || sim.thermostat_type == "nose_hoover_np" || sim.thermostat_type == "nose_hoover_np_dim") {
+ClassicalObservable::ClassicalObservable(Params& param_obj, int _freq, const std::string& _out_unit, int this_bead, 
+                                         dVec& prev_coord, dVec& coord, BosonicExchangeBase& bosonic_exchange, Thermostat& thermostat, dVec& momenta) :
+    EnergyObservable(param_obj, _freq, _out_unit, this_bead, prev_coord, coord, bosonic_exchange), 
+    thermostat(thermostat), 
+    momenta(momenta) {
+    thermostat_type = std::get<std::string>(param_obj.sim["thermostat_type"]);
+    if (thermostat_type == "nose_hoover" || thermostat_type == "nose_hoover_np" || thermostat_type == "nose_hoover_np_dim") {
         initialize({ "temperature", "cl_kinetic", "cl_spring", "nh_energy" });
     }
     else {
@@ -21,8 +25,8 @@ ClassicalObservable::ClassicalObservable(const Simulation& _sim, int _freq, cons
 void ClassicalObservable::calculate() {
     calculateKineticEnergy();
     calculateSpringEnergy();
-    if (sim.thermostat_type == "nose_hoover" || sim.thermostat_type == "nose_hoover_np" || sim.thermostat_type == "nose_hoover_np_dim") {
-        quantities["nh_energy"] = Units::convertToUser("energy", out_unit, sim.thermostat->getAdditionToH());
+    if (thermostat_type == "nose_hoover" || thermostat_type == "nose_hoover_np" || thermostat_type == "nose_hoover_np_dim") {
+        quantities["nh_energy"] = Units::convertToUser("energy", out_unit, thermostat.getAdditionToH());
     }
 }
 
@@ -32,13 +36,13 @@ void ClassicalObservable::calculate() {
 void ClassicalObservable::calculateKineticEnergy() {
     double kinetic_energy = 0.0;
 
-    for (int ptcl_idx = 0; ptcl_idx < sim.natoms; ++ptcl_idx) {
+    for (int ptcl_idx = 0; ptcl_idx < natoms; ++ptcl_idx) {
         for (int axis = 0; axis < NDIM; ++axis) {
-            kinetic_energy += sim.momenta(ptcl_idx, axis) * sim.momenta(ptcl_idx, axis);
+            kinetic_energy += momenta(ptcl_idx, axis) * momenta(ptcl_idx, axis);
         }
     }
 
-    kinetic_energy *= 0.5 / sim.mass;
+    kinetic_energy *= 0.5 / mass;
     quantities["cl_kinetic"] = Units::convertToUser("energy", out_unit, kinetic_energy);
 
     // Temperature is calculated according to Tolman's equipartition theorem as the average kinetic 
@@ -46,14 +50,14 @@ void ClassicalObservable::calculateKineticEnergy() {
     // See [J. Chem. Theory Comput. 2019, 15, 1, 84-94.] for a discussion on the topic.
 
     /// @todo When zeroing the center of mass motion, the number of degrees of freedom must be reduced by NDIM.
-    double dof = NDIM * sim.natoms * sim.nbeads;
+    double dof = NDIM * natoms * nbeads;
     double temperature = 2.0 * kinetic_energy / (dof * Constants::kB);
 
     // In the i-Pi convention, the ring-polymer simulation is performed at a temperature that is P times higher
     // than the actual (quantum) temperature. Therefore, to ensure the quantum temperature is calculated correctly,
     // one must divide the classical temperature by the number of beads.
 #if IPI_CONVENTION
-    temperature /= sim.nbeads;
+    temperature /= nbeads;
 #endif
 
     /// @todo Allow conversion to different temperature units
@@ -68,10 +72,10 @@ void ClassicalObservable::calculateKineticEnergy() {
 void ClassicalObservable::calculateSpringEnergy() {
     double spring_energy;
 
-    if (sim.this_bead == 0 && sim.bosonic) {
-        spring_energy = sim.bosonic_exchange->effectivePotential();
+    if (this_bead == 0 && bosonic) {
+        spring_energy = bosonic_exchange.effectivePotential();
     } else {
-        spring_energy = sim.classicalSpringEnergy();
+        spring_energy = classicalSpringEnergy();
     }
     quantities["cl_spring"] = Units::convertToUser("energy", out_unit, spring_energy);
 }

--- a/src/observables/classical.cpp
+++ b/src/observables/classical.cpp
@@ -73,6 +73,5 @@ void ClassicalObservable::calculateSpringEnergy() {
     } else {
         spring_energy = sim.classicalSpringEnergy();
     }
-
     quantities["cl_spring"] = Units::convertToUser("energy", out_unit, spring_energy);
 }

--- a/src/observables/gsf_action.cpp
+++ b/src/observables/gsf_action.cpp
@@ -8,7 +8,8 @@
  */
 GSFActionObservable::GSFActionObservable(Params& param_obj, int _freq, const std::string& _out_unit, int this_bead,
                                          Potential& ext_potential, Potential& int_potential, dVec& coord) :
-    Observable(param_obj, _freq, _out_unit, this_bead), ext_potential(ext_potential), int_potential(int_potential), coord(coord) {
+    Observable(param_obj, _freq, _out_unit, this_bead), 
+    ext_potential(ext_potential), int_potential(int_potential), coord(coord) {
     getVariant(param_obj.sys["natoms"], natoms);
     getVariant(param_obj.sim["nbeads"], nbeads);
     getVariant(param_obj.sim["pbc"], pbc);

--- a/src/observables/gsf_action.cpp
+++ b/src/observables/gsf_action.cpp
@@ -1,14 +1,31 @@
 #include "observables/gsf_action.h"
-#include "simulation.h"
+#include "potentials.h"
 #include "units.h"
 #include <ranges>
-#include "mpi.h"
 
 /**
  * @brief Constructor for the class handling observables associated with the GSF action.
  */
-GSFActionObservable::GSFActionObservable(const Simulation& _sim, int _freq, const std::string& _out_unit) :
-    Observable(_sim, _freq, _out_unit) {
+GSFActionObservable::GSFActionObservable(Params& param_obj, int _freq, const std::string& _out_unit, int this_bead,
+                                         Potential& ext_potential, Potential& int_potential, dVec& coord) :
+    Observable(param_obj, _freq, _out_unit, this_bead), ext_potential(ext_potential), int_potential(int_potential), coord(coord) {
+    getVariant(param_obj.sys["natoms"], natoms);
+    getVariant(param_obj.sim["nbeads"], nbeads);
+    getVariant(param_obj.sim["pbc"], pbc);
+    getVariant(param_obj.sys["size"], size);
+    
+    double temperature;
+    getVariant(param_obj.sys["temperature"], temperature);
+    beta = 1.0 / (Constants::kB * temperature);
+
+    std::string interaction_potential_name = std::get<std::string>(param_obj.interaction_pot["name"]);
+    int_pot_cutoff = (interaction_potential_name == "free") ? 0.0 : std::get<double>(param_obj.interaction_pot["cutoff"]);
+
+    double mass;
+    getVariant(param_obj.sys["mass"], mass);
+    double omega_p = nbeads / (beta * Constants::hbar);
+    spring_constant = mass * omega_p * omega_p;
+
     initialize({ "w_gsf", "pot_gsf" });
 }
 
@@ -21,19 +38,19 @@ GSFActionObservable::GSFActionObservable(const Simulation& _sim, int _freq, cons
 void GSFActionObservable::calculate() {
     double alpha = 0.0;
 
-    double total_potential = sim.ext_potential->V(sim.coord);
+    double total_potential = ext_potential.V(coord);
 
-    dVec gradients(sim.natoms);
-    gradients = sim.ext_potential->gradV(sim.coord);
+    dVec gradients(natoms);
+    gradients = ext_potential.gradV(coord);
 
-    if (sim.int_pot_cutoff != 0.0) {
-        for (int ptcl_one = 0; ptcl_one < sim.natoms; ++ptcl_one) {
-            for (int ptcl_two = ptcl_one + 1; ptcl_two < sim.natoms; ++ptcl_two) {
-                dVec diff = sim.getSeparation(ptcl_one, ptcl_two, MINIM);  // Vectorial distance
+    if (int_pot_cutoff != 0.0) {
+        for (int ptcl_one = 0; ptcl_one < natoms; ++ptcl_one) {
+            for (int ptcl_two = ptcl_one + 1; ptcl_two < natoms; ++ptcl_two) {
+                dVec diff = getSeparation(ptcl_one, ptcl_two, MINIM, pbc, coord, size);  // Vectorial distance
 
-                if (const double distance = diff.norm(); distance < sim.int_pot_cutoff || sim.int_pot_cutoff < 0.0) {
-                    total_potential += sim.int_potential->V(diff);
-                    gradients = gradients + sim.int_potential->gradV(diff);
+                if (const double distance = diff.norm(); distance < int_pot_cutoff || int_pot_cutoff < 0.0) {
+                    total_potential += int_potential.V(diff);
+                    gradients = gradients + int_potential.gradV(diff);
                 }
             }
         }
@@ -41,7 +58,7 @@ void GSFActionObservable::calculate() {
 
     double total_force_squared = 0.0;
 
-    for (int ptcl_idx = 0; ptcl_idx < sim.natoms; ++ptcl_idx) {
+    for (int ptcl_idx = 0; ptcl_idx < natoms; ++ptcl_idx) {
         for (int axis = 0; axis < NDIM; ++axis) {
             total_force_squared += gradients(ptcl_idx, axis) * gradients(ptcl_idx, axis);
         }
@@ -50,24 +67,24 @@ void GSFActionObservable::calculate() {
     // Ensure the spring constant is in Tuckerman's convention
     
 #if IPI_CONVENTION
-    double sp_constant = sim.spring_constant / sim.nbeads;
+    double sp_constant = spring_constant / nbeads;
 #else
-    double sp_constant = sim.spring_constant;
+    double sp_constant = spring_constant;
 #endif
 
-    double potential_term = total_potential / (3 * sim.nbeads);
-    double force_squared_term = total_force_squared / (9 * sp_constant * sim.nbeads * sim.nbeads);
+    double potential_term = total_potential / (3 * nbeads);
+    double force_squared_term = total_force_squared / (9 * sp_constant * nbeads * nbeads);
 
-    if (sim.this_bead % 2 != 0) {
+    if (this_bead % 2 != 0) {
         // Odd
         quantities["w_gsf"] = (-1.0) * potential_term + alpha * force_squared_term;
 
         // Evaluate the potential energy estimator only for odd imaginary-time slices
-        quantities["pot_gsf"] = Units::convertToUser("energy", out_unit, total_potential / (0.5 * sim.nbeads));
+        quantities["pot_gsf"] = Units::convertToUser("energy", out_unit, total_potential / (0.5 * nbeads));
     } else {
         // Even
         quantities["w_gsf"] = potential_term + (1 - alpha) * force_squared_term;
     }
 
-    quantities["w_gsf"] *= (-1.0) * sim.beta;
+    quantities["w_gsf"] *= (-1.0) * beta;
 }

--- a/src/observables/quantum.cpp
+++ b/src/observables/quantum.cpp
@@ -1,0 +1,97 @@
+#include "observables/quantum.h"
+#include "bosonic_exchange.h"
+#include "potentials.h"
+#include "units.h"
+#include <ranges>
+
+/**
+ * @brief Energy observable class constructor.
+ */
+QuantumObservable::QuantumObservable(Params& param_obj, int _freq, const std::string& _out_unit, int this_bead, 
+                                     dVec& prev_coord, dVec& coord, BosonicExchangeBase& bosonic_exchange,
+                                     Potential& ext_potential, Potential& int_potential, dVec& physical_forces) :
+    EnergyObservable(param_obj, _freq, _out_unit, this_bead, prev_coord, coord, bosonic_exchange),
+    ext_potential(ext_potential), int_potential(int_potential), physical_forces(physical_forces) {
+        
+    external_potential_name = std::get<std::string>(param_obj.external_pot["name"]);
+    interaction_potential_name = std::get<std::string>(param_obj.interaction_pot["name"]);
+    if (external_potential_name == "free" && interaction_potential_name == "free") {
+        initialize({ "kinetic" });
+    } else if (external_potential_name == "free" || interaction_potential_name == "free") {
+        initialize({ "kinetic", "potential", "virial" });
+    } else {
+        initialize({ "kinetic", "potential", "ext_pot", "int_pot", "virial" });
+    }
+    double temperature;
+    getVariant(param_obj.sys["temperature"], temperature);
+    beta = 1.0 / (Constants::kB * temperature);
+}
+
+void QuantumObservable::calculate() {
+    calculateKinetic();
+    calculatePotential();
+}
+
+/**
+ * @brief Calculates the quantum kinetic energy of the system using the primitive kinetic energy estimator.
+ * Works both for distinguishable particles and bosons.
+ */
+void QuantumObservable::calculateKinetic() {
+    // First, add the constant factor of d*N*P/(2*beta) to the kinetic energy (per bead)
+    quantities["kinetic"] = 0.5 * NDIM * natoms / beta;
+
+    // Then, subtract the spring energies. In the case of bosons, the exterior
+    // spring energy requires separate treatment.
+    if (this_bead == 0 && bosonic) {
+        quantities["kinetic"] += bosonic_exchange.primEstimator();
+    } else {
+        double spring_energy = classicalSpringEnergy();
+#if IPI_CONVENTION
+        spring_energy /= nbeads;
+#endif
+
+        quantities["kinetic"] -= spring_energy;
+    }
+
+    quantities["kinetic"] = Units::convertToUser("energy", out_unit, quantities["kinetic"]);
+}
+
+/**
+ * @brief Calculates the quantum potential energy of the system, based on the potential energy estimator.
+ * The potential energy is the sum of the external potential energy and the interaction potential energy
+ * across all time-slices, divided by the number of beads. In addition, the method calculates the virial
+ * kinetic energy of the system.
+ */
+void QuantumObservable::calculatePotential() {
+    double potential = 0.0;  // Total potential energy
+    double virial = 0.0;     // Virial kinetic energy
+    double int_pot = 0.0;    // Potential energy due to interactions
+    double ext_pot = 0.0;    // Potential energy due to external field
+
+    if (external_potential_name != "free") {
+        ext_pot = ext_potential.V(coord);
+        potential += ext_pot;
+
+        for (int ptcl_idx = 0; ptcl_idx < natoms; ++ptcl_idx) {
+            for (int axis = 0; axis < NDIM; ++axis) {
+                virial -= coord(ptcl_idx, axis) * physical_forces(ptcl_idx, axis);
+            }
+        }
+    }
+
+    if (external_potential_name != "free" && interaction_potential_name != "free") {
+        ext_pot /= nbeads;
+        int_pot /= nbeads;
+
+        quantities["ext_pot"] = Units::convertToUser("energy", out_unit, ext_pot);
+        quantities["int_pot"] = Units::convertToUser("energy", out_unit, int_pot);
+    }
+
+    if (external_potential_name != "free" || interaction_potential_name != "free") {
+        potential /= nbeads;
+        virial *= 0.5 / nbeads;
+
+        quantities["potential"] = Units::convertToUser("energy", out_unit, potential);
+        quantities["virial"] = Units::convertToUser("energy", out_unit, virial);
+    }
+}

--- a/src/propagators/cartesian_propagator.cpp
+++ b/src/propagators/cartesian_propagator.cpp
@@ -1,8 +1,8 @@
 #include "propagators/velocity_verlet.h"
 #include "simulation.h"
 
-VelocityVerletPropagator::VelocityVerletPropagator(Simulation& _sim, Params& param_obj, dVec& coord, dVec& momenta, dVec& forces) : 
-    Propagator(_sim, param_obj, coord, momenta, forces) {
+VelocityVerletPropagator::VelocityVerletPropagator(Params& param_obj, dVec& coord, dVec& momenta, dVec& forces) : 
+    Propagator(param_obj, coord, momenta, forces) {
 }
 
 void VelocityVerletPropagator::preForceStep() {

--- a/src/propagators/cartesian_propagator.cpp
+++ b/src/propagators/cartesian_propagator.cpp
@@ -1,23 +1,23 @@
-#include "propagators/velocity_verlet.h"
+#include "propagators/cartesian_propagator.h"
 #include "simulation.h"
 
-VelocityVerletPropagator::VelocityVerletPropagator(Params& param_obj, dVec& coord, dVec& momenta, dVec& forces) : 
+CartesianPropagator::CartesianPropagator(Params& param_obj, dVec& coord, dVec& momenta, dVec& forces) : 
     Propagator(param_obj, coord, momenta, forces) {
 }
 
-void VelocityVerletPropagator::preForceStep() {
+void CartesianPropagator::preForceStep() {
     // First step: momenta are propagated by half a step ("B" step)
     momentStep();
 
     // Second step: positions are propagated using the new momenta ("A" step)
     coordsStep();
 }
-void VelocityVerletPropagator::postForceStep() {
+void CartesianPropagator::postForceStep() {
     // Final step: momenta are propagated once more ("B" step)
     momentStep();
 }
 
-void VelocityVerletPropagator::momentStep() {
+void CartesianPropagator::momentStep() {
     for (int ptcl_idx = 0; ptcl_idx < natoms; ++ptcl_idx) {
         for (int axis = 0; axis < NDIM; ++axis) {
             momenta(ptcl_idx, axis) += 0.5 * dt * forces(ptcl_idx, axis);
@@ -25,7 +25,7 @@ void VelocityVerletPropagator::momentStep() {
     }
 }
 
-void VelocityVerletPropagator::coordsStep() {
+void CartesianPropagator::coordsStep() {
     for (int ptcl_idx = 0; ptcl_idx < natoms; ++ptcl_idx) {
         for (int axis = 0; axis < NDIM; ++axis) {
             coord(ptcl_idx, axis) += dt * momenta(ptcl_idx, axis) / mass;

--- a/src/propagators/cartesian_propagator.cpp
+++ b/src/propagators/cartesian_propagator.cpp
@@ -1,5 +1,4 @@
 #include "propagators/cartesian_propagator.h"
-#include "simulation.h"
 
 CartesianPropagator::CartesianPropagator(Params& param_obj, dVec& coord, dVec& momenta, dVec& forces) : 
     Propagator(param_obj, coord, momenta, forces) {

--- a/src/propagators/normal_modes_propagator.cpp
+++ b/src/propagators/normal_modes_propagator.cpp
@@ -1,65 +1,85 @@
 #include "propagators/normal_modes_propagator.h"
 #include "normal_modes.h"
 #include "simulation.h"
+#include "params.h"
 
 #include <numbers>
 
-NormalModesPropagator::NormalModesPropagator(Simulation& _sim, Params& param_obj, dVec& coord, dVec& momenta, dVec& forces,
-                                            dVec& physical_forces, dVec& spring_forces) : 
-    Propagator(_sim, param_obj, coord, momenta, forces),
+NormalModesPropagator::NormalModesPropagator(Params& param_obj, dVec& coord, dVec& momenta, dVec& forces,
+                                            dVec& physical_forces, dVec& spring_forces, dVec& prev_coord, dVec& next_coord,
+                          int this_bead, NormalModes& normal_modes) : 
+    Propagator(param_obj, coord, momenta, forces),
     physical_forces(physical_forces),
-    spring_forces(spring_forces)
+    spring_forces(spring_forces),
+    prev_coord(prev_coord),
+    next_coord(next_coord),
+    this_bead(this_bead),
+    normal_modes(normal_modes)
 {
+    getVariant(param_obj.sim["nbeads"], nbeads);
+    getVariant(param_obj.sim["bosonic"], bosonic);
+
+    double temperature;
+    getVariant(param_obj.sys["temperature"], temperature);
+#if IPI_CONVENTION
+    // i-Pi convention [J. Chem. Phys. 133, 124104 (2010)]
+    double omega_p = nbeads * Constants::kB * temperature / Constants::hbar;
+#else
+    // Tuckerman convention
+    double omega_p = sqrt(nbeads) * Constants::kB * temperature / Constants::hbar;
+#endif
+
     // Frequencies
-    freq = 2 * sim.omega_p * sin(sim.this_bead * std::numbers::pi / sim.nbeads); 
-    c = cos(freq * sim.dt);
-    s = sin(freq * sim.dt);
-    m_omega = sim.mass * freq;    
+    freq = 2 * omega_p * sin(this_bead * std::numbers::pi / nbeads); 
+    c = cos(freq * dt);
+    s = sin(freq * dt);
+    m_omega = mass * freq;
+    spring_constant = mass * omega_p * omega_p; 
 }
 
 void NormalModesPropagator::preForceStep() {
     // Propagate momenta under external forces
     momentaExternalForces();
 
-    sim.normal_modes->shareData();
+    normal_modes.shareData();
 
     MPI_Barrier(MPI_COMM_WORLD);
-    for (int ptcl_idx = 0; ptcl_idx < sim.natoms; ++ptcl_idx) {
+    for (int ptcl_idx = 0; ptcl_idx < natoms; ++ptcl_idx) {
         for (int axis = 0; axis < NDIM; ++axis) {
-            const int glob_idx = sim.normal_modes->globIndexAtom(axis, ptcl_idx);
+            const int glob_idx = normal_modes.globIndexAtom(axis, ptcl_idx);
             // Cartesian-to-nm transformation
-            double coord_nm = sim.normal_modes->coordCarToNM(glob_idx);
-            double momentum_nm = sim.normal_modes->momentumCarToNM(glob_idx);
+            double coord_nm = normal_modes.coordCarToNM(glob_idx);
+            double momentum_nm = normal_modes.momentumCarToNM(glob_idx);
             // Time propagation
             if (freq == 0) {
-                sim.normal_modes->arr_coord_nm[glob_idx + sim.this_bead] = coord_nm + sim.dt / sim.mass * momentum_nm;
-                sim.normal_modes->arr_momenta_nm[glob_idx + sim.this_bead] = momentum_nm;
+                normal_modes.arr_coord_nm[glob_idx + this_bead] = coord_nm + dt / mass * momentum_nm;
+                normal_modes.arr_momenta_nm[glob_idx + this_bead] = momentum_nm;
             } else {
-                sim.normal_modes->arr_coord_nm[glob_idx + sim.this_bead] = c * coord_nm + s / m_omega * momentum_nm;
-                sim.normal_modes->arr_momenta_nm[glob_idx + sim.this_bead] = (-1) * m_omega * s * coord_nm + c * momentum_nm;
+                normal_modes.arr_coord_nm[glob_idx + this_bead] = c * coord_nm + s / m_omega * momentum_nm;
+                normal_modes.arr_momenta_nm[glob_idx + this_bead] = (-1) * m_omega * s * coord_nm + c * momentum_nm;
             }
         }
     }
 
     MPI_Barrier(MPI_COMM_WORLD);
-    for (int ptcl_idx = 0; ptcl_idx < sim.natoms; ++ptcl_idx) {
+    for (int ptcl_idx = 0; ptcl_idx < natoms; ++ptcl_idx) {
         for (int axis = 0; axis < NDIM; ++axis) {
-            int glob_idx = sim.normal_modes->globIndexAtom(axis, ptcl_idx);
+            int glob_idx = normal_modes.globIndexAtom(axis, ptcl_idx);
             // NM-to-Cartesian transformation
-            double coord_cartesian = sim.normal_modes->coordNMToCar(glob_idx); 
-            double momentum_cartesian = sim.normal_modes->momentumNMToCar(glob_idx);
-            sim.normal_modes->arr_coord_cartesian[glob_idx + sim.this_bead] = coord_cartesian;
-            sim.normal_modes->arr_momenta_cartesian[glob_idx + sim.this_bead] = momentum_cartesian;
+            double coord_cartesian = normal_modes.coordNMToCar(glob_idx); 
+            double momentum_cartesian = normal_modes.momentumNMToCar(glob_idx);
+            normal_modes.arr_coord_cartesian[glob_idx + this_bead] = coord_cartesian;
+            normal_modes.arr_momenta_cartesian[glob_idx + this_bead] = momentum_cartesian;
         }
     }
 
     // Update forces
     MPI_Barrier(MPI_COMM_WORLD);
-    for (int ptcl_idx = 0; ptcl_idx < sim.natoms; ++ptcl_idx) {
+    for (int ptcl_idx = 0; ptcl_idx < natoms; ++ptcl_idx) {
         for (int axis = 0; axis < NDIM; ++axis) {
-            int glob_idx = sim.normal_modes->globIndexAtom(axis, ptcl_idx);
-            sim.coord(ptcl_idx, axis) = sim.normal_modes->arr_coord_cartesian[glob_idx + sim.this_bead];
-            sim.momenta(ptcl_idx, axis) = sim.normal_modes->arr_momenta_cartesian[glob_idx + sim.this_bead];
+            int glob_idx = normal_modes.globIndexAtom(axis, ptcl_idx);
+            coord(ptcl_idx, axis) = normal_modes.arr_coord_cartesian[glob_idx + this_bead];
+            momenta(ptcl_idx, axis) = normal_modes.arr_momenta_cartesian[glob_idx + this_bead];
         }
     }
 }
@@ -69,33 +89,33 @@ void NormalModesPropagator::postForceStep() {
 }
 
 void NormalModesPropagator::momentaExternalForces() {
-    if (!sim.bosonic) {
-        for (int ptcl_idx = 0; ptcl_idx < sim.natoms; ++ptcl_idx)
+    if (!bosonic) {
+        for (int ptcl_idx = 0; ptcl_idx < natoms; ++ptcl_idx)
             for (int axis = 0; axis < NDIM; ++axis)
 #if IPI_CONVENTION
-                sim.momenta(ptcl_idx, axis) += 0.5 * sim.dt * physical_forces(ptcl_idx, axis);
+                momenta(ptcl_idx, axis) += 0.5 * dt * physical_forces(ptcl_idx, axis);
 #else
-                sim.momenta(ptcl_idx, axis) += 0.5 * sim.dt * physical_forces(ptcl_idx, axis) / sim.nbeads;
+                momenta(ptcl_idx, axis) += 0.5 * dt * physical_forces(ptcl_idx, axis) / nbeads;
 #endif
-    } else if (sim.this_bead == 0 || sim.this_bead == sim.nbeads - 1) {
+    } else if (this_bead == 0 || this_bead == nbeads - 1) {
         double inner_springs;
-        for (int ptcl_idx = 0; ptcl_idx < sim.natoms; ++ptcl_idx) {
+        for (int ptcl_idx = 0; ptcl_idx < natoms; ++ptcl_idx) {
             for (int axis = 0; axis < NDIM; ++axis) {
-                inner_springs = -sim.spring_constant * (2 * sim.coord(ptcl_idx, axis) - sim.prev_coord(ptcl_idx, axis) - sim.next_coord(ptcl_idx, axis));
+                inner_springs = -spring_constant * (2 * coord(ptcl_idx, axis) - prev_coord(ptcl_idx, axis) - next_coord(ptcl_idx, axis));
 #if IPI_CONVENTION
-                sim.momenta(ptcl_idx, axis) += 0.5 * sim.dt * (physical_forces(ptcl_idx, axis) + spring_forces(ptcl_idx, axis) - inner_springs);
+                momenta(ptcl_idx, axis) += 0.5 * dt * (physical_forces(ptcl_idx, axis) + spring_forces(ptcl_idx, axis) - inner_springs);
 #else
-                sim.momenta(ptcl_idx, axis) += 0.5 * sim.dt * (physical_forces(ptcl_idx, axis) / sim.nbeads + spring_forces(ptcl_idx, axis) - inner_springs);
+                momenta(ptcl_idx, axis) += 0.5 * dt * (physical_forces(ptcl_idx, axis) / nbeads + spring_forces(ptcl_idx, axis) - inner_springs);
 #endif
             }
         }
     } else {
-        for (int ptcl_idx = 0; ptcl_idx < sim.natoms; ++ptcl_idx)
+        for (int ptcl_idx = 0; ptcl_idx < natoms; ++ptcl_idx)
             for (int axis = 0; axis < NDIM; ++axis)
 #if IPI_CONVENTION
-                sim.momenta(ptcl_idx, axis) += 0.5 * sim.dt * physical_forces(ptcl_idx, axis);
+                momenta(ptcl_idx, axis) += 0.5 * dt * physical_forces(ptcl_idx, axis);
 #else
-                sim.momenta(ptcl_idx, axis) += 0.5 * sim.dt * physical_forces(ptcl_idx, axis) / sim.nbeads;
+                momenta(ptcl_idx, axis) += 0.5 * dt * physical_forces(ptcl_idx, axis) / nbeads;
 #endif
     }
 }

--- a/src/propagators/normal_modes_propagator.cpp
+++ b/src/propagators/normal_modes_propagator.cpp
@@ -1,8 +1,6 @@
 #include "propagators/normal_modes_propagator.h"
 #include "normal_modes.h"
-#include "simulation.h"
 #include "params.h"
-
 #include <numbers>
 
 NormalModesPropagator::NormalModesPropagator(Params& param_obj, dVec& coord, dVec& momenta, dVec& forces,
@@ -34,13 +32,12 @@ NormalModesPropagator::NormalModesPropagator(Params& param_obj, dVec& coord, dVe
     c = cos(freq * dt);
     s = sin(freq * dt);
     m_omega = mass * freq;
-    spring_constant = mass * omega_p * omega_p; 
+    spring_constant = mass * omega_p * omega_p;
 }
 
 void NormalModesPropagator::preForceStep() {
     // Propagate momenta under external forces
     momentaExternalForces();
-
     normal_modes.shareData();
 
     MPI_Barrier(MPI_COMM_WORLD);

--- a/src/propagators/normal_modes_propagator.cpp
+++ b/src/propagators/normal_modes_propagator.cpp
@@ -4,8 +4,8 @@
 
 #include <numbers>
 
-NormalModesPropagator::NormalModesPropagator(Simulation& _sim) : 
-    Propagator(_sim),
+NormalModesPropagator::NormalModesPropagator(Simulation& _sim, Params& param_obj, dVec& coord, dVec& momenta, dVec& forces) : 
+    Propagator(_sim, param_obj, coord, momenta, forces),
     ext_forces(_sim.natoms),
     spring_forces(_sim.natoms)
 {

--- a/src/propagators/normal_modes_propagator.cpp
+++ b/src/propagators/normal_modes_propagator.cpp
@@ -4,10 +4,11 @@
 
 #include <numbers>
 
-NormalModesPropagator::NormalModesPropagator(Simulation& _sim, Params& param_obj, dVec& coord, dVec& momenta, dVec& forces) : 
+NormalModesPropagator::NormalModesPropagator(Simulation& _sim, Params& param_obj, dVec& coord, dVec& momenta, dVec& forces,
+                                            dVec& ext_forces, dVec& spring_forces) : 
     Propagator(_sim, param_obj, coord, momenta, forces),
-    ext_forces(_sim.natoms),
-    spring_forces(_sim.natoms)
+    ext_forces(ext_forces),
+    spring_forces(spring_forces)
 {
     // Frequencies
     freq = 2 * sim.omega_p * sin(sim.this_bead * std::numbers::pi / sim.nbeads); 
@@ -63,9 +64,6 @@ void NormalModesPropagator::preForceStep() {
     }
 }
 void NormalModesPropagator::postForceStep() {
-    sim.updatePhysicalForces(ext_forces);
-    sim.updateSpringForces(spring_forces);
-    
     // Propagate momenta under external forces
     momentaExternalForces();
 }

--- a/src/propagators/normal_modes_propagator.cpp
+++ b/src/propagators/normal_modes_propagator.cpp
@@ -16,7 +16,7 @@ NormalModesPropagator::NormalModesPropagator(Simulation& _sim) :
     m_omega = sim.mass * freq;    
 }
 
-void NormalModesPropagator::step() {
+void NormalModesPropagator::preForceStep() {
     // Propagate momenta under external forces
     momentaExternalForces();
 
@@ -61,8 +61,8 @@ void NormalModesPropagator::step() {
             sim.momenta(ptcl_idx, axis) = sim.normal_modes->arr_momenta_cartesian[glob_idx + sim.this_bead];
         }
     }
-    sim.updateNeighboringCoordinates();
-    sim.updateForces();
+}
+void NormalModesPropagator::postForceStep() {
     sim.updatePhysicalForces(ext_forces);
     sim.updateSpringForces(spring_forces);
     

--- a/src/propagators/normal_modes_propagator.cpp
+++ b/src/propagators/normal_modes_propagator.cpp
@@ -5,9 +5,9 @@
 #include <numbers>
 
 NormalModesPropagator::NormalModesPropagator(Simulation& _sim, Params& param_obj, dVec& coord, dVec& momenta, dVec& forces,
-                                            dVec& ext_forces, dVec& spring_forces) : 
+                                            dVec& physical_forces, dVec& spring_forces) : 
     Propagator(_sim, param_obj, coord, momenta, forces),
-    ext_forces(ext_forces),
+    physical_forces(physical_forces),
     spring_forces(spring_forces)
 {
     // Frequencies
@@ -73,9 +73,9 @@ void NormalModesPropagator::momentaExternalForces() {
         for (int ptcl_idx = 0; ptcl_idx < sim.natoms; ++ptcl_idx)
             for (int axis = 0; axis < NDIM; ++axis)
 #if IPI_CONVENTION
-                sim.momenta(ptcl_idx, axis) += 0.5 * sim.dt * ext_forces(ptcl_idx, axis);
+                sim.momenta(ptcl_idx, axis) += 0.5 * sim.dt * physical_forces(ptcl_idx, axis);
 #else
-                sim.momenta(ptcl_idx, axis) += 0.5 * sim.dt * ext_forces(ptcl_idx, axis) / sim.nbeads;
+                sim.momenta(ptcl_idx, axis) += 0.5 * sim.dt * physical_forces(ptcl_idx, axis) / sim.nbeads;
 #endif
     } else if (sim.this_bead == 0 || sim.this_bead == sim.nbeads - 1) {
         double inner_springs;
@@ -83,9 +83,9 @@ void NormalModesPropagator::momentaExternalForces() {
             for (int axis = 0; axis < NDIM; ++axis) {
                 inner_springs = -sim.spring_constant * (2 * sim.coord(ptcl_idx, axis) - sim.prev_coord(ptcl_idx, axis) - sim.next_coord(ptcl_idx, axis));
 #if IPI_CONVENTION
-                sim.momenta(ptcl_idx, axis) += 0.5 * sim.dt * (ext_forces(ptcl_idx, axis) + spring_forces(ptcl_idx, axis) - inner_springs);
+                sim.momenta(ptcl_idx, axis) += 0.5 * sim.dt * (physical_forces(ptcl_idx, axis) + spring_forces(ptcl_idx, axis) - inner_springs);
 #else
-                sim.momenta(ptcl_idx, axis) += 0.5 * sim.dt * (ext_forces(ptcl_idx, axis) / sim.nbeads + spring_forces(ptcl_idx, axis) - inner_springs);
+                sim.momenta(ptcl_idx, axis) += 0.5 * sim.dt * (physical_forces(ptcl_idx, axis) / sim.nbeads + spring_forces(ptcl_idx, axis) - inner_springs);
 #endif
             }
         }
@@ -93,9 +93,9 @@ void NormalModesPropagator::momentaExternalForces() {
         for (int ptcl_idx = 0; ptcl_idx < sim.natoms; ++ptcl_idx)
             for (int axis = 0; axis < NDIM; ++axis)
 #if IPI_CONVENTION
-                sim.momenta(ptcl_idx, axis) += 0.5 * sim.dt * ext_forces(ptcl_idx, axis);
+                sim.momenta(ptcl_idx, axis) += 0.5 * sim.dt * physical_forces(ptcl_idx, axis);
 #else
-                sim.momenta(ptcl_idx, axis) += 0.5 * sim.dt * ext_forces(ptcl_idx, axis) / sim.nbeads;
+                sim.momenta(ptcl_idx, axis) += 0.5 * sim.dt * physical_forces(ptcl_idx, axis) / sim.nbeads;
 #endif
     }
 }

--- a/src/propagators/propagator.cpp
+++ b/src/propagators/propagator.cpp
@@ -1,3 +1,9 @@
 #include "propagators/propagator.h"
+#include "params.h"
 
-Propagator::Propagator(Simulation& _sim) : sim(_sim) {}
+Propagator::Propagator(Simulation& _sim, Params& param_obj, dVec& coord, dVec& momenta, dVec& forces) : 
+sim(_sim), coord(coord), momenta(momenta), forces(forces) {
+    getVariant(param_obj.sys["natoms"], natoms);
+    getVariant(param_obj.sim["dt"], dt);
+    getVariant(param_obj.sys["mass"], mass); 
+}

--- a/src/propagators/propagator.cpp
+++ b/src/propagators/propagator.cpp
@@ -1,8 +1,8 @@
 #include "propagators/propagator.h"
 #include "params.h"
 
-Propagator::Propagator(Simulation& _sim, Params& param_obj, dVec& coord, dVec& momenta, dVec& forces) : 
-sim(_sim), coord(coord), momenta(momenta), forces(forces) {
+Propagator::Propagator(Params& param_obj, dVec& coord, dVec& momenta, dVec& forces) : 
+    coord(coord), momenta(momenta), forces(forces) {
     getVariant(param_obj.sys["natoms"], natoms);
     getVariant(param_obj.sim["dt"], dt);
     getVariant(param_obj.sys["mass"], mass); 

--- a/src/propagators/velocity_verlet.cpp
+++ b/src/propagators/velocity_verlet.cpp
@@ -1,7 +1,8 @@
 #include "propagators/velocity_verlet.h"
 #include "simulation.h"
 
-VelocityVerletPropagator::VelocityVerletPropagator(Simulation& _sim) : Propagator(_sim) {
+VelocityVerletPropagator::VelocityVerletPropagator(Simulation& _sim, Params& param_obj, dVec& coord, dVec& momenta, dVec& forces) : 
+    Propagator(_sim, param_obj, coord, momenta, forces) {
 }
 
 void VelocityVerletPropagator::preForceStep() {
@@ -17,17 +18,17 @@ void VelocityVerletPropagator::postForceStep() {
 }
 
 void VelocityVerletPropagator::momentStep() {
-    for (int ptcl_idx = 0; ptcl_idx < sim.natoms; ++ptcl_idx) {
+    for (int ptcl_idx = 0; ptcl_idx < natoms; ++ptcl_idx) {
         for (int axis = 0; axis < NDIM; ++axis) {
-            sim.momenta(ptcl_idx, axis) += 0.5 * sim.dt * sim.forces(ptcl_idx, axis);
+            momenta(ptcl_idx, axis) += 0.5 * dt * forces(ptcl_idx, axis);
         }
     }
 }
 
 void VelocityVerletPropagator::coordsStep() {
-    for (int ptcl_idx = 0; ptcl_idx < sim.natoms; ++ptcl_idx) {
+    for (int ptcl_idx = 0; ptcl_idx < natoms; ++ptcl_idx) {
         for (int axis = 0; axis < NDIM; ++axis) {
-            sim.coord(ptcl_idx, axis) += sim.dt * sim.momenta(ptcl_idx, axis) / sim.mass;
+            coord(ptcl_idx, axis) += dt * momenta(ptcl_idx, axis) / mass;
         }
     }
 }

--- a/src/propagators/velocity_verlet.cpp
+++ b/src/propagators/velocity_verlet.cpp
@@ -4,24 +4,19 @@
 VelocityVerletPropagator::VelocityVerletPropagator(Simulation& _sim) : Propagator(_sim) {
 }
 
-void VelocityVerletPropagator::step() {
+void VelocityVerletPropagator::preForceStep() {
     // First step: momenta are propagated by half a step ("B" step)
     momentStep();
 
     // Second step: positions are propagated using the new momenta ("A" step)
     coordsStep();
-
-    // Remember to update the neighboring coordinates after every coordinate propagation
-    sim.updateNeighboringCoordinates();
-
-    // Third step: forces are updated using the new positions
-    sim.updateForces();
-
-    // Fourth step: momenta are propagated once more ("B" step)
+}
+void VelocityVerletPropagator::postForceStep() {
+    // Final step: momenta are propagated once more ("B" step)
     momentStep();
 }
 
-void Propagator::momentStep() {
+void VelocityVerletPropagator::momentStep() {
     for (int ptcl_idx = 0; ptcl_idx < sim.natoms; ++ptcl_idx) {
         for (int axis = 0; axis < NDIM; ++axis) {
             sim.momenta(ptcl_idx, axis) += 0.5 * sim.dt * sim.forces(ptcl_idx, axis);
@@ -29,7 +24,7 @@ void Propagator::momentStep() {
     }
 }
 
-void Propagator::coordsStep() {
+void VelocityVerletPropagator::coordsStep() {
     for (int ptcl_idx = 0; ptcl_idx < sim.natoms; ++ptcl_idx) {
         for (int axis = 0; axis < NDIM; ++axis) {
             sim.coord(ptcl_idx, axis) += sim.dt * sim.momenta(ptcl_idx, axis) / sim.mass;

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -78,7 +78,7 @@ Simulation::Simulation(const int& rank, const int& nproc, Params& param_obj, uns
     initializePropagator(param_obj);
     initializeThermostat(param_obj);
     initializeExchangeAlgorithm();
-    
+
     // Initialize the potential based on the input
     external_potential_name = std::get<std::string>(param_obj.external_pot["name"]);
     interaction_potential_name = std::get<std::string>(param_obj.interaction_pot["name"]);
@@ -659,7 +659,7 @@ void Simulation::initializePropagator(Params& param_obj) {
         propagator = std::make_unique<CartesianPropagator>(param_obj, coord, momenta, forces);
     } else if (propagator_type == "normal_modes") {
         propagator = std::make_unique<NormalModesPropagator>(param_obj, coord, momenta, forces,
-                    spring_forces, physical_forces, prev_coord, next_coord, this_bead, *normal_modes);
+                    physical_forces, spring_forces, prev_coord, next_coord, this_bead, *normal_modes);
     }
 }
 

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -248,7 +248,10 @@ void Simulation::run() {
             zeroMomentum();
         }
 
-        propagator->step();
+        propagator->preForceStep();
+        updateNeighboringCoordinates();
+        updateForces();
+        propagator->postForceStep();
 
         thermostat->step();
 

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -49,6 +49,7 @@ Simulation::Simulation(const int& rank, const int& nproc, Params& param_obj, uns
 #endif
 
     spring_constant = mass * omega_p * omega_p;
+    beta_half_k = thermo_beta * 0.5 * spring_constant;
 
     // Get the seed from the config file
     getVariant(param_obj.sim["seed"], params_seed);
@@ -660,7 +661,7 @@ void Simulation::initializePropagator(const VariantMap& sim_params) {
 /**
  * Initializes the thermostat based on the input parameters.
  *
- * @param sim_params Simulation parameters object containing information about the thermostat.
+ * @param param_obj Params object with all parameters of the simulation.
  */
 void Simulation::initializeThermostat(Params& param_obj) {
     thermostat_type = std::get<std::string>(param_obj.sim["thermostat_type"]);

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -61,7 +61,7 @@ Simulation::Simulation(const int& rank, const int& nproc, Params& param_obj, uns
     init_pos_type = std::get<std::string>(param_obj.sim["init_pos_type"]);
     init_vel_type = std::get<std::string>(param_obj.sim["init_vel_type"]);
 
-    normal_modes = std::make_unique<NormalModes>(*this);
+    normal_modes = std::make_unique<NormalModes>(param_obj, this_bead, coord, momenta);
 
     // Initialize the coordinate, momenta, and force arrays
     coord = dVec(natoms);

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -655,7 +655,7 @@ void Simulation::initializePropagator(Params& param_obj) {
     propagator_type = std::get<std::string>(param_obj.sim.at("propagator_type"));
     
     if (propagator_type == "cartesian") {
-        propagator = std::make_unique<VelocityVerletPropagator>(param_obj, coord, momenta, forces);
+        propagator = std::make_unique<CartesianPropagator>(param_obj, coord, momenta, forces);
     } else if (propagator_type == "normal_modes") {
         propagator = std::make_unique<NormalModesPropagator>(param_obj, coord, momenta, forces,
                     spring_forces, physical_forces, prev_coord, next_coord, this_bead, *normal_modes);

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -425,7 +425,12 @@ void Simulation::updateSpringForces() {
  */
 void Simulation::updatePhysicalForces() {
     // Calculate the external forces acting on the particles
-    physical_forces = (-1.0) * ext_potential->gradV(coord);
+    dVec external_forces = (-1.0) * ext_potential->gradV(coord);
+    for (int ptcl_one = 0; ptcl_one < natoms; ++ptcl_one) {
+        for (int axis = 0; axis < NDIM; ++axis) {
+            physical_forces(ptcl_one, axis) = external_forces(ptcl_one, axis);
+        }
+    }
 
     if (int_pot_cutoff != 0.0) {
         for (int ptcl_one = 0; ptcl_one < natoms; ++ptcl_one) {

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -61,10 +61,6 @@ Simulation::Simulation(const int& rank, const int& nproc, Params& param_obj, uns
     init_vel_type = std::get<std::string>(param_obj.sim["init_vel_type"]);
 
     normal_modes = std::make_unique<NormalModes>(*this);
-    // Initialize the propagator, thermostat, and exchange algorithm
-    initializePropagator(param_obj);
-    initializeThermostat(param_obj);
-    initializeExchangeAlgorithm();
 
     // Initialize the coordinate, momenta, and force arrays
     coord = dVec(natoms);
@@ -78,6 +74,11 @@ Simulation::Simulation(const int& rank, const int& nproc, Params& param_obj, uns
     initializePositions(coord, param_obj.sim);
     initializeMomenta(momenta, param_obj.sim);
 
+    // Initialize the propagator, thermostat, and exchange algorithm
+    initializePropagator(param_obj);
+    initializeThermostat(param_obj);
+    initializeExchangeAlgorithm();
+    
     // Initialize the potential based on the input
     external_potential_name = std::get<std::string>(param_obj.external_pot["name"]);
     interaction_potential_name = std::get<std::string>(param_obj.interaction_pot["name"]);

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -655,9 +655,10 @@ void Simulation::initializePropagator(Params& param_obj) {
     propagator_type = std::get<std::string>(param_obj.sim.at("propagator_type"));
     
     if (propagator_type == "cartesian") {
-        propagator = std::make_unique<VelocityVerletPropagator>(*this, param_obj, coord, momenta, forces);
+        propagator = std::make_unique<VelocityVerletPropagator>(param_obj, coord, momenta, forces);
     } else if (propagator_type == "normal_modes") {
-        propagator = std::make_unique<NormalModesPropagator>(*this, param_obj, coord, momenta, forces, physical_forces, spring_forces);
+        propagator = std::make_unique<NormalModesPropagator>(param_obj, coord, momenta, forces,
+                    spring_forces, physical_forces, prev_coord, next_coord, this_bead, *normal_modes);
     }
 }
 

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -233,7 +233,6 @@ void Simulation::run() {
     // Main loop performing molecular dynamics steps
     for (int step = 0; step <= steps; ++step) {
         setStep(step);
-
         for (const auto& observable : observables) {
             observable->resetValues();
         }
@@ -249,6 +248,7 @@ void Simulation::run() {
         }
 
         propagator->step();
+
         thermostat->step();
 
         // Zero momentum after every thermostat step (if needed)

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -62,7 +62,7 @@ Simulation::Simulation(const int& rank, const int& nproc, Params& param_obj, uns
 
     normal_modes = std::make_unique<NormalModes>(*this);
     // Initialize the propagator, thermostat, and exchange algorithm
-    initializePropagator(param_obj.sim);
+    initializePropagator(param_obj);
     initializeThermostat(param_obj);
     initializeExchangeAlgorithm();
 
@@ -649,15 +649,15 @@ std::unique_ptr<Potential> Simulation::initializePotential(const std::string& po
 /**
  * Initializes the propagator based on the input parameters.
  *
- * @param sim_params Simulation parameters object containing information about the propagator.
- */
-void Simulation::initializePropagator(const VariantMap& sim_params) {
-    propagator_type = std::get<std::string>(sim_params.at("propagator_type"));
+ * @param param_obj Params object with all parameters of the simulation.
+ *  */
+void Simulation::initializePropagator(Params& param_obj) {
+    propagator_type = std::get<std::string>(param_obj.sim.at("propagator_type"));
     
     if (propagator_type == "cartesian") {
-        propagator = std::make_unique<VelocityVerletPropagator>(*this);
+        propagator = std::make_unique<VelocityVerletPropagator>(*this, param_obj, coord, momenta, forces);
     } else if (propagator_type == "normal_modes") {
-        propagator = std::make_unique<NormalModesPropagator>(*this);
+        propagator = std::make_unique<NormalModesPropagator>(*this, param_obj, coord, momenta, forces);
     }
 }
 

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -12,6 +12,7 @@
 #include "thermostats.h"
 #include "normal_modes.h"
 #include "simulation.h"
+#include <iostream>
 
 Simulation::Simulation(const int& rank, const int& nproc, Params& param_obj, unsigned int seed) :
     bosonic_exchange(nullptr),
@@ -99,10 +100,34 @@ Simulation::Simulation(const int& rank, const int& nproc, Params& param_obj, uns
     updateNeighboringCoordinates();
 
     initializeStates(param_obj);
-    initializeObservables(param_obj.observables);
+    initializeObservables(param_obj);
 }
 
 Simulation::~Simulation() = default;
+
+double Simulation::classicalSpringEnergy() const {
+    assert(!bosonic || (bosonic && this_bead != 0));
+
+    double interior_spring_energy = 0.0;
+
+    for (int ptcl_idx = 0; ptcl_idx < natoms; ++ptcl_idx) {
+        for (int axis = 0; axis < NDIM; ++axis) {
+            double diff = prev_coord(ptcl_idx, axis) - coord(ptcl_idx, axis);
+
+#if MINIM
+            if (pbc) {
+                applyMinimumImage(diff, size);
+            }
+#endif
+
+            interior_spring_energy += diff * diff;
+        }
+    }
+
+    interior_spring_energy *= 0.5 * spring_constant;
+    return interior_spring_energy;
+}
+
 
 int Simulation::getStep() const {
     return md_step;
@@ -437,7 +462,7 @@ void Simulation::updatePhysicalForces() {
             for (int ptcl_two = ptcl_one + 1; ptcl_two < natoms; ++ptcl_two) {
                 // Get the vector distance between the two particles.
                 // Here "diff" contains just one vector of dimension NDIM.
-                dVec diff = getSeparation(ptcl_one, ptcl_two, MINIM);
+                dVec diff = getSeparation(ptcl_one, ptcl_two, MINIM, pbc, coord, size);
 
                 // If the distance between the particles exceeds the cutoff length
                 // then we assume the interaction is negligible and do not bother
@@ -455,63 +480,6 @@ void Simulation::updatePhysicalForces() {
             }
         }
     }
-}
-
-/**
- * Calculates the spring energy contribution of the current and the previous time-slice,
- * provided they are classical, i.e., are not affected by bosonic exchange.
- * If the simulation is bosonic, the function is callable only for the interior connections.
- *
- * @return Classical spring energy contribution of the current and the previous time-slice.
- */
-double Simulation::classicalSpringEnergy() const {
-    assert(!bosonic || (bosonic && this_bead != 0));
-
-    double interior_spring_energy = 0.0;
-
-    for (int ptcl_idx = 0; ptcl_idx < natoms; ++ptcl_idx) {
-        for (int axis = 0; axis < NDIM; ++axis) {
-            double diff = prev_coord(ptcl_idx, axis) - coord(ptcl_idx, axis);
-
-#if MINIM
-            if (pbc) {
-                applyMinimumImage(diff, size);
-            }
-#endif
-
-            interior_spring_energy += diff * diff;
-        }
-    }
-
-    interior_spring_energy *= 0.5 * spring_constant;
-
-    return interior_spring_energy;
-}
-
-/**
- * Returns the vectorial distance between two particles at the same imaginary timeslice.
- * Mathematically equivalent to r1-r2, where r1 and r2 are the position-vectors
- * of the first and second particles, respectively. In the case of PBC, there is an
- * option to return the minimal distance between the two particles.
- * 
- * @param first_ptcl Index of the first particle.
- * @param second_ptcl Index of the second particle.
- * @param minimum_image Flag determining whether the minimum image convention should be applied.
- * @return Vectorial distance between the two particles.
- */
-dVec Simulation::getSeparation(int first_ptcl, int second_ptcl, bool minimum_image) const {
-    dVec sep;
-
-    for (int axis = 0; axis < NDIM; ++axis) {
-        double diff = coord(first_ptcl, axis) - coord(second_ptcl, axis);
-
-        if (pbc && minimum_image)
-            applyMinimumImage(diff, size);
-
-        sep(0, axis) = diff;
-    }
-
-    return sep;
 }
 
 /**
@@ -798,16 +766,16 @@ void Simulation::initializeStates(Params& param_obj) {
  * Initializes an observable based on the input parameters. Initialization occurs only if the
  * observable is enabled (the units are not set to "off").
  *
- * @param sim_params Simulation parameters object containing information about the observables.
+ * @param param_obj Params object with all parameters of the simulation.
  * @param param_key Key of the parameter in the simulation parameters object.
  * @param observable_name Name of the observable.
  */
-void Simulation::addObservableIfEnabled(const StringMap& sim_params, const std::string& param_key, const std::string& observable_name) {
-    if (const std::string& units = sim_params.at(param_key); units != "off") {
+void Simulation::addObservableIfEnabled(Params& param_obj, const std::string& param_key, const std::string& observable_name) {
+    if (const std::string& units = param_obj.observables.at(param_key); units != "off") {
         if (units == "none") {
-            observables.push_back(ObservableFactory::createQuantity(observable_name, *this, sfreq, ""));
+            observables.push_back(ObservableFactory::createQuantity(*this, param_obj, observable_name, sfreq, "", this_bead));
         } else {
-            observables.push_back(ObservableFactory::createQuantity(observable_name, *this, sfreq, units));
+            observables.push_back(ObservableFactory::createQuantity(*this, param_obj, observable_name, sfreq, units, this_bead));
         }
     }
 }
@@ -815,17 +783,17 @@ void Simulation::addObservableIfEnabled(const StringMap& sim_params, const std::
 /**
  * Method for initializing all the requested observables.
  *
- * @param sim_params Simulation parameters object containing information about the observables.
+ * @param param_obj Params object with all parameters of the simulation.
  */
-void Simulation::initializeObservables(const StringMap& sim_params) {
-    addObservableIfEnabled(sim_params, "energy", "energy");
-    addObservableIfEnabled(sim_params, "classical", "classical");
+void Simulation::initializeObservables(Params& param_obj) {
+    addObservableIfEnabled(param_obj, "energy", "energy");
+    addObservableIfEnabled(param_obj, "classical", "classical");
 
     if (bosonic) {
-        addObservableIfEnabled(sim_params, "bosonic", "bosonic");
+        addObservableIfEnabled(param_obj, "bosonic", "bosonic");
     }
 
-    addObservableIfEnabled(sim_params, "gsf", "gsf");
+    addObservableIfEnabled(param_obj, "gsf", "gsf");
 }
 
 /**

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -78,7 +78,7 @@ Simulation::Simulation(const int& rank, const int& nproc, Params& param_obj, uns
     // Initialize the propagator, thermostat, and exchange algorithm
     initializePropagator(param_obj);
     initializeThermostat(param_obj);
-    initializeExchangeAlgorithm();
+    initializeExchangeAlgorithm(param_obj);
 
     // Initialize the potential based on the input
     external_potential_name = std::get<std::string>(param_obj.external_pot["name"]);
@@ -663,15 +663,15 @@ void Simulation::initializeThermostat(Params& param_obj) {
 /**
  * Initializes the bosonic exchange algorithm.
  */
-void Simulation::initializeExchangeAlgorithm() {
+void Simulation::initializeExchangeAlgorithm(Params& param_obj) {
     bosonic = bosonic && (nbeads > 1); // Bosonic exchange is only possible for P>1
     is_bosonic_bead = bosonic && (this_bead == 0 || this_bead == nbeads - 1);
 
     if (is_bosonic_bead) {
 #if FACTORIAL_BOSONIC_ALGORITHM
-        bosonic_exchange = std::make_unique<FactorialBosonicExchange>(*this);
+        bosonic_exchange = std::make_unique<FactorialBosonicExchange>(param_obj, coord, prev_coord, next_coord, this_bead);
 #else
-        bosonic_exchange = std::make_unique<BosonicExchange>(*this);
+        bosonic_exchange = std::make_unique<BosonicExchange>(param_obj, coord, prev_coord, next_coord, this_bead);
 #endif
     }
 }

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -413,7 +413,6 @@ void Simulation::updateSpringForces() {
                 applyMinimumImage(diff_next, size);
             }
 #endif
-
             spring_forces(ptcl_idx, axis) = spring_constant * (diff_prev + diff_next);
         }
     }

--- a/src/states/force.cpp
+++ b/src/states/force.cpp
@@ -7,8 +7,8 @@
 /**
  * @brief Force state class constructor.
  */
-ForceState::ForceState(const Simulation& _sim, int _freq, const std::string& _out_unit) :
-    State(_sim, _freq, _out_unit) {
+ForceState::ForceState(Params& param_obj, int _freq, const std::string& _out_unit, dVec& _forces) :
+    State(param_obj, _freq, _out_unit), forces(_forces) {
     // Check the correctness of the provided unit ahead of time
     try {
         Units::convertToUser("force", out_unit, 1.0);
@@ -20,8 +20,8 @@ ForceState::ForceState(const Simulation& _sim, int _freq, const std::string& _ou
 /**
  * @brief Initializes the forces dat file.
  */
-void ForceState::initialize() {
-    out_file.open(std::format("{}/force_{}.dat", Output::FOLDER_NAME, sim.this_bead), std::ios::out | std::ios::app);
+void ForceState::initialize(int this_bead) {
+    out_file.open(std::format("{}/force_{}.dat", Output::FOLDER_NAME, this_bead), std::ios::out | std::ios::app);
     //out_file << std::format("# Units: {}\n", out_unit);
 }
 
@@ -34,14 +34,14 @@ void ForceState::output(int step) {
     if (step % freq != 0)
         return;
 
-    out_file << std::format("{}\n", sim.natoms);
+    out_file << std::format("{}\n", natoms);
     out_file << std::format("Step {}\n", step);
 
-    for (int ptcl_idx = 0; ptcl_idx < sim.natoms; ++ptcl_idx) {
+    for (int ptcl_idx = 0; ptcl_idx < natoms; ++ptcl_idx) {
         out_file << (ptcl_idx + 1) << " 1";
 
         for (int axis = 0; axis < NDIM; ++axis) {
-            out_file << std::format(" {:^20.12e}", Units::convertToUser("force", out_unit, sim.forces(ptcl_idx, axis)));
+            out_file << std::format(" {:^20.12e}", Units::convertToUser("force", out_unit, forces(ptcl_idx, axis)));
         }
 #if NDIM == 1
         out_file << " 0.0 0.0";

--- a/src/states/position.cpp
+++ b/src/states/position.cpp
@@ -7,8 +7,8 @@
 /**
  * @brief Position state class constructor.
  */
-PositionState::PositionState(const Simulation& _sim, int _freq, const std::string& _out_unit) :
-    State(_sim, _freq, _out_unit) {
+PositionState::PositionState(Params& param_obj, int _freq, const std::string& _out_unit, dVec& coord) :
+    State(param_obj, _freq, _out_unit), coord(coord) {
     // Check the correctness of the provided unit ahead of time
     try {
         Units::convertToUser("length", out_unit, 1.0);
@@ -20,8 +20,8 @@ PositionState::PositionState(const Simulation& _sim, int _freq, const std::strin
 /**
  * @brief Initializes the coordinates xyz file.
  */
-void PositionState::initialize() {
-    out_file.open(std::format("{}/position_{}.xyz", Output::FOLDER_NAME, sim.this_bead), std::ios::out | std::ios::app);
+void PositionState::initialize(int this_bead) {
+    out_file.open(std::format("{}/position_{}.xyz", Output::FOLDER_NAME, this_bead), std::ios::out | std::ios::app);
     //out_file << std::format("# Units: {}\n", out_unit);
 }
 
@@ -34,15 +34,15 @@ void PositionState::output(int step) {
     if (step % freq != 0)
         return;
 
-    out_file << std::format("{}\n", sim.natoms);
+    out_file << std::format("{}\n", natoms);
     //out_file << std::format(" Atoms. MD step: {}\n", step);
     out_file << std::format("Step {}\n", step);
 
-    for (int ptcl_idx = 0; ptcl_idx < sim.natoms; ++ptcl_idx) {
+    for (int ptcl_idx = 0; ptcl_idx < natoms; ++ptcl_idx) {
         out_file << "1";
 
         for (int axis = 0; axis < NDIM; ++axis) {
-            out_file << std::format(" {:^20.12e}", Units::convertToUser("length", out_unit, sim.coord(ptcl_idx, axis)));
+            out_file << std::format(" {:^20.12e}", Units::convertToUser("length", out_unit, coord(ptcl_idx, axis)));
         }
 #if NDIM == 1
         out_file << " 0.0 0.0";

--- a/src/states/state.cpp
+++ b/src/states/state.cpp
@@ -4,8 +4,10 @@
 /**
  * @brief Generic state class constructor
  */
-State::State(const Simulation& _sim, int _freq, const std::string& _out_unit) :
-    sim(_sim), freq(_freq), out_unit(_out_unit) {
+State::State(Params& param_obj, int _freq, const std::string& _out_unit) :
+    freq(_freq), out_unit(_out_unit) {
+    getVariant(param_obj.sim["nbeads"], nbeads);
+    getVariant(param_obj.sys["natoms"], natoms);
 }
 
 /**
@@ -28,15 +30,16 @@ State::~State() {
  * @throw std::invalid_argument If the state type is unknown
  */
 std::unique_ptr<State> StateFactory::createQuantity(const std::string& state_type,
-    const Simulation& _sim,
+    Simulation& sim, 
+    Params& param_obj,
     int _freq,
     const std::string& _out_unit) {
     if (state_type == "position") {
-        return std::make_unique<PositionState>(_sim, _freq, _out_unit);
+        return std::make_unique<PositionState>(param_obj, _freq, _out_unit, sim.coord);
     } else if (state_type == "velocity") {
-        return std::make_unique<VelocityState>(_sim, _freq, _out_unit);
+        return std::make_unique<VelocityState>(param_obj, _freq, _out_unit, sim.momenta);
     } else if (state_type == "force") {
-        return std::make_unique<ForceState>(_sim, _freq, _out_unit);
+        return std::make_unique<ForceState>(param_obj, _freq, _out_unit, sim.forces);
     } else {
         throw std::invalid_argument("Unknown state type.");
     }

--- a/src/states/velocity.cpp
+++ b/src/states/velocity.cpp
@@ -7,8 +7,9 @@
 /**
  * @brief Velocity state class constructor.
  */
-VelocityState::VelocityState(const Simulation& _sim, int _freq, const std::string& _out_unit) :
-    State(_sim, _freq, _out_unit) {
+VelocityState::VelocityState(Params& param_obj, int _freq, const std::string& _out_unit, dVec& momenta) :
+    State(param_obj, _freq, _out_unit), momenta(momenta) {
+    getVariant(param_obj.sys["mass"], mass);
     // Check the correctness of the provided unit ahead of time
     try {
         Units::convertToUser("velocity", out_unit, 1.0);
@@ -20,8 +21,8 @@ VelocityState::VelocityState(const Simulation& _sim, int _freq, const std::strin
 /**
  * @brief Initializes the velocities dat file.
  */
-void VelocityState::initialize() {
-    out_file.open(std::format("{}/velocity_{}.dat", Output::FOLDER_NAME, sim.this_bead), std::ios::out | std::ios::app);
+void VelocityState::initialize(int this_bead) {
+    out_file.open(std::format("{}/velocity_{}.dat", Output::FOLDER_NAME, this_bead), std::ios::out | std::ios::app);
     //out_file << std::format("# Units: {}\n", out_unit);
 }
 
@@ -34,14 +35,14 @@ void VelocityState::output(int step) {
     if (step % freq != 0)
         return;
 
-    out_file << std::format("{}\n", sim.natoms);
+    out_file << std::format("{}\n", natoms);
     out_file << std::format("Step {}\n", step);
 
-    for (int ptcl_idx = 0; ptcl_idx < sim.natoms; ++ptcl_idx) {
+    for (int ptcl_idx = 0; ptcl_idx < natoms; ++ptcl_idx) {
         out_file << (ptcl_idx + 1) << " 1";
 
         for (int axis = 0; axis < NDIM; ++axis) {
-            out_file << std::format(" {:^20.12e}", Units::convertToUser("velocity", out_unit, sim.momenta(ptcl_idx, axis) / sim.mass));
+            out_file << std::format(" {:^20.12e}", Units::convertToUser("velocity", out_unit, momenta(ptcl_idx, axis) / mass));
         }
 #if NDIM == 1
         out_file << " 0.0 0.0";

--- a/src/thermostats/langevin.cpp
+++ b/src/thermostats/langevin.cpp
@@ -12,7 +12,7 @@ LangevinThermostat::LangevinThermostat(Coupling& coupling, Params& param_obj, in
     getVariant(param_obj.sim["gamma"], gamma);
     friction_coefficient = exp(-0.5 * gamma * dt);
     noise_coefficient = sqrt((1 - friction_coefficient * friction_coefficient) * mass / thermo_beta);
-    int params_seed;
+    unsigned int params_seed;
     getVariant(param_obj.sim["seed"], params_seed);
     mars_gen = std::make_unique<RanMars>(params_seed + rank);
 }

--- a/src/thermostats/langevin.cpp
+++ b/src/thermostats/langevin.cpp
@@ -7,19 +7,24 @@
 #include <numbers>
 
 // A class for a Langevin thermostat 
-LangevinThermostat::LangevinThermostat(Simulation& _sim, bool normal_modes) : Thermostat(_sim, normal_modes) {
-    friction_coefficient = exp(-0.5 * sim.gamma * sim.dt);
-    noise_coefficient = sqrt((1 - friction_coefficient * friction_coefficient) * sim.mass / sim.thermo_beta);
+LangevinThermostat::LangevinThermostat(Coupling& coupling, Params& param_obj, int rank) : Thermostat(coupling, param_obj) {
+    double gamma;
+    getVariant(param_obj.sim["gamma"], gamma);
+    friction_coefficient = exp(-0.5 * gamma * dt);
+    noise_coefficient = sqrt((1 - friction_coefficient * friction_coefficient) * mass / thermo_beta);
+    int params_seed;
+    getVariant(param_obj.sim["seed"], params_seed);
+    mars_gen = std::make_unique<RanMars>(params_seed + rank);
 }
 
 void LangevinThermostat::momentaUpdate() {
     //std::normal_distribution<double> normal; // At the moment we use the Marsaglia generator
 
-    for (int ptcl_idx = 0; ptcl_idx < sim.natoms; ++ptcl_idx) {
+    for (int ptcl_idx = 0; ptcl_idx < natoms; ++ptcl_idx) {
         for (int axis = 0; axis < NDIM; ++axis) {
-            double noise = sim.mars_gen->gaussian(); // LAMMPS pimd/langevin random numbers
-            double momentum_for_calc = coupling->getMomentumForCalc(ptcl_idx, axis);
-            double& momentum_for_update = coupling->getMomentumForUpdate(ptcl_idx, axis);
+            double noise = mars_gen->gaussian(); // LAMMPS pimd/langevin random numbers
+            double momentum_for_calc = coupling.getMomentumForCalc(ptcl_idx, axis);
+            double& momentum_for_update = coupling.getMomentumForUpdate(ptcl_idx, axis);
             // Perturb the momenta with a Langevin thermostat
             momentum_for_update = friction_coefficient * momentum_for_calc + noise_coefficient * noise;
         }

--- a/src/thermostats/thermostat.cpp
+++ b/src/thermostats/thermostat.cpp
@@ -2,20 +2,26 @@
 #include "simulation.h"
 #include "thermostats/thermostat_coupling.h"
 
-Thermostat::Thermostat(Simulation& _sim, bool normal_modes) : sim(_sim) {
-    // Choose coupling (Cartesian coords or normal modes of distinguishable ring polymers)
-    if (normal_modes) {
-        coupling = std::make_unique<NMCoupling>(_sim);
-    } else {
-        coupling = std::make_unique<CartesianCoupling>(_sim);
-    }
+Thermostat::Thermostat(Coupling& coupling, Params& param_obj) : coupling(coupling) {
+    getVariant(param_obj.sys["natoms"], natoms);
+    getVariant(param_obj.sim["nbeads"], nbeads);
+    getVariant(param_obj.sys["mass"], mass);
+    getVariant(param_obj.sim["dt"], dt);
+    
+#if IPI_CONVENTION
+    // i-Pi convention [J. Chem. Phys. 133, 124104 (2010)]
+    thermo_beta = beta / nbeads;
+#else
+    // Tuckerman convention
+    thermo_beta = beta;
+#endif
 }
 
 // This is the step function of a general thermostat, called in the simulation's run loop
 void Thermostat::step() {
-    coupling->mpiCommunication();
+    coupling.mpiCommunication();
     momentaUpdate();
-    coupling->updateCoupledMomenta();
+    coupling.updateCoupledMomenta();
 }
 
 // This is an update of the momenta within the thermostat step, unique for each thermostat

--- a/src/thermostats/thermostat.cpp
+++ b/src/thermostats/thermostat.cpp
@@ -8,6 +8,10 @@ Thermostat::Thermostat(Coupling& coupling, Params& param_obj) : coupling(couplin
     getVariant(param_obj.sys["mass"], mass);
     getVariant(param_obj.sim["dt"], dt);
     
+    double temperature;
+    getVariant(param_obj.sys["temperature"], temperature);
+    beta = 1.0 / (Constants::kB * temperature);
+
 #if IPI_CONVENTION
     // i-Pi convention [J. Chem. Phys. 133, 124104 (2010)]
     thermo_beta = beta / nbeads;


### PR DESCRIPTION
Removed all Simulation& across the code. Now, the different classes only have references to the essentials of the main Simulation object.